### PR TITLE
[dist] uglify 2.7.5 has insourceMap fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "tar-fs": "~1.8.1",
     "through2": "~2.0.0",
     "toml": "^2.3.0",
-    "uglify-js": "git://github.com/Swaagie/UglifyJS2.git#fcb4f2f",
+    "uglify-js": "^2.7.5",
     "walk": "~2.3.9",
     "webpack": "^1.12.12",
     "winston": "^2.2.0"


### PR DESCRIPTION
See commit https://github.com/mishoo/UglifyJS2/commit/98f330658f5cd0dfb3004815d05f123f4110c2e0 on 29 nov in https://github.com/mishoo/UglifyJS2/compare/v2.7.4...v2.7.5