### PR TITLE
Single install builds

### DIFF
--- a/lib/constructor/index.js
+++ b/lib/constructor/index.js
@@ -414,19 +414,20 @@ Constructor.prototype.prepare = function prepare(spec, content, next) {
  *
  * @function checkAndDownload
  * @param {Object} spec - specification for build
- * @param {String} tarpath - path to put the tarball
+ * @param {Object} paths - paths object
  * @param {Function} next - go to the next step and run builds
  * @param {Function} install - this is the case where we need to run install as package-version doesnt exist yet
+ * @returns {undefined}
  * @api private
  */
 Constructor.prototype.checkAndDownload = function checkAndDownload(spec, paths, next, install) {
-  if (!this.cdnup) return install();
+  if (!this.cdnup) return void install();
 
   const pkgcloud = this.cdnup.client;
   const filename = `${encodeURIComponent(spec.name)}-${spec.version}.tgz`;
 
-  pkgcloud.getFile(this.cdnup.bucket, filename, (err, file) => {
-    if (err || !file) return install();
+  return void pkgcloud.getFile(this.cdnup.bucket, filename, (err, file) => {
+    if (err || !file) return void install();
 
     pkgcloud.download({
       container: this.cdnup.bucket,

--- a/lib/constructor/index.js
+++ b/lib/constructor/index.js
@@ -380,7 +380,7 @@ Constructor.prototype.prepare = function prepare(spec, content, next) {
   const tarRoot = config.tarballs || path.join(os.tmpdir(), 'tarballs');
   const uniq = `${encodeURIComponent(spec.name)}-${spec.version}-${spec.env}-${crypto.randomBytes(5).toString('hex')}`;
   const outputPath = path.join(outputRoot, uniq);
-  const tarPath = path.join(tarRoot, uniq + '.tgz');
+  const tarball = path.join(tarRoot, uniq + '.tgz');
 
   async.parallel([
     async.apply(mkdirp, outputRoot),
@@ -393,16 +393,16 @@ Constructor.prototype.prepare = function prepare(spec, content, next) {
     // First see if this package has already been built for a different env, we
     // should only build a single version once
     //
-    this.checkAndDownload(spec, { tarball: tarPath }, next, () => {
+    this.checkAndDownload(spec, { tarball }, next, () => {
       async.series({
         unpack: this.unpack.bind(this, { content, outputPath }),
         install: this.install.bind(this, spec, pkgDir),
-        pack: this.pack.bind(this, pkgDir, tarPath),
-        upload: this.upload.bind(this, spec, tarPath)
+        pack: this.pack.bind(this, pkgDir, tarball),
+        upload: this.upload.bind(this, spec, tarball)
       }, (err) => {
         if (err) return next(err);
 
-        next(null, { install: outputPath, tarball: tarPath });
+        next(null, { install: outputPath, tarball });
       });
     });
   });

--- a/lib/constructor/index.js
+++ b/lib/constructor/index.js
@@ -389,16 +389,51 @@ Constructor.prototype.prepare = function prepare(spec, content, next) {
     if (err) return next(err);
 
     const pkgDir = path.join(outputPath, 'package');
-    async.series({
-      unpack: this.unpack.bind(this, { content, outputPath }),
-      install: this.install.bind(this, spec, pkgDir),
-      pack: this.pack.bind(this, pkgDir, tarPath),
-      upload: this.upload.bind(this, spec, tarPath)
-    }, (err) => {
-      if (err) return next(err);
+    //
+    // First see if this package has already been built for a different env, we
+    // should only build a single version once
+    //
+    this.checkAndDownload(spec, { tarball: tarPath }, next, () => {
+      async.series({
+        unpack: this.unpack.bind(this, { content, outputPath }),
+        install: this.install.bind(this, spec, pkgDir),
+        pack: this.pack.bind(this, pkgDir, tarPath),
+        upload: this.upload.bind(this, spec, tarPath)
+      }, (err) => {
+        if (err) return next(err);
 
-      next(null, { install: outputPath, tarball: tarPath });
+        next(null, { install: outputPath, tarball: tarPath });
+      });
     });
+  });
+};
+
+/**
+ * Check to see if this package version combo exists and download and use that
+ * tarball instead if it does
+ *
+ * @function checkAndDownload
+ * @param {Object} spec - specification for build
+ * @param {String} tarpath - path to put the tarball
+ * @param {Function} next - go to the next step and run builds
+ * @param {Function} install - this is the case where we need to run install as package-version doesnt exist yet
+ * @api private
+ */
+Constructor.prototype.checkAndDownload = function checkAndDownload(spec, paths, next, install) {
+  if (!this.cdnup) return install();
+
+  const pkgcloud = this.cdnup.client;
+  const filename = `${encodeURIComponent(spec.name)}-${spec.version}.tgz`;
+
+  pkgcloud.getFile(this.cdnup.bucket, filename, (err, file) => {
+    if (err || !file) return install();
+
+    pkgcloud.download({
+      container: this.cdnup.bucket,
+      remote: filename
+    }).pipe(fs.createWriteStream(paths.tarball))
+      .once('error', next)
+      .on('finish', () => next(null, paths));
   });
 };
 


### PR DESCRIPTION
This allows for immutable builds by first checking for a tarball for the version that was tagged. This should ensure only 1 is created. There is a subtle race condition that could happen if a dist-tag happens too soon after a publish and the install -> upload process has not completed yet. This is an edge case worth mentioning but can be avoided in future refactors.