### PR TITLE
Better logging – everywhere. Simplification of how app.config is used

### DIFF
--- a/lib/constructor/fitting.js
+++ b/lib/constructor/fitting.js
@@ -11,7 +11,7 @@ module.exports = function fitting(data, options) {
   //
   const classy = options.classification;
   const keyword = options.keyword || 'check';
-  const match = '';
+  let match = '';
 
   //
   // The classification can also be read directly from the data.

--- a/lib/constructor/fitting.js
+++ b/lib/constructor/fitting.js
@@ -1,0 +1,39 @@
+'use strict';
+
+//
+// Extract the type of build we are doing
+//
+module.exports = function fitting(data, options) {
+  options = options || {};
+
+  //
+  // Allow additional rules to be defined and merge against the default.
+  //
+  const classy = options.classification;
+  const keyword = options.keyword || 'check';
+  const match = '';
+
+  //
+  // The classification can also be read directly from the data.
+  // Allow opt-in for a `keyword`. This defaults to the `check` property.
+  //
+  if (data[keyword] in classy) return data[keyword];
+
+  //
+  // Check if there are keywords in the package.json that gives some intel on
+  // which project/team created these packages.
+  //
+  if (!Array.isArray(data.keywords)) data.keywords = [];
+
+  Object.keys(classy).some(function each(project) {
+    const keywords = classy[project];
+
+    if (keywords.some(function some(keyword) {
+      return !!~data.keywords.indexOf(keyword);
+    })) return !!(match = project);
+
+    return false;
+  });
+
+  return match;
+};

--- a/lib/constructor/index.js
+++ b/lib/constructor/index.js
@@ -12,6 +12,7 @@ const crypto = require('crypto');
 const mkdirp = require('mkdirp');
 const async = require('async');
 const errs = require('errs');
+const fitting = require('./fitting');
 const rmrf = require('./rmrf');
 const tar = require('tar-fs');
 const once = require('one-time');
@@ -903,41 +904,3 @@ module.exports = function preboot(app, options, done) {
   app.construct = new Constructor(app, config);
   done();
 };
-
-//
-// Extract the type of build we are doing
-//
-function fitting(data, options) {
-  options = options || {};
-
-  //
-  // Allow additional rules to be defined and merge against the default.
-  //
-  var classy = options.classification,
-    keyword = options.keyword || 'check',
-    match = '';
-
-  //
-  // The classification can also be read directly from the data.
-  // Allow opt-in for a `keyword`. This defaults to the `check` property.
-  //
-  if (data[keyword] in classy) return data[keyword];
-
-  //
-  // Check if there are keywords in the package.json that gives some intel on
-  // which project/team created these packages.
-  //
-  if (!Array.isArray(data.keywords)) data.keywords = [];
-
-  Object.keys(classy).some(function each(project) {
-    var keywords = classy[project];
-
-    if (keywords.some(function some(keyword) {
-      return !!~data.keywords.indexOf(keyword);
-    })) return !!(match = project);
-
-    return false;
-  });
-
-  return match;
-}

--- a/lib/constructor/index.js
+++ b/lib/constructor/index.js
@@ -73,6 +73,15 @@ function Constructor(app, options) {
   this.models = app.models;
   this.throttle = options.throttle || app.config.get('throttle') || 10;
 
+  this.timeout = options.timeout || 15 * 6E4;
+  this.purgeRetries = (options.retries || 0) + 5;
+
+  this.source = options.source;
+  this.target = options.target;
+  this.rootDir = options.target || os.tmpdir();
+  this.installRoot = options.install || path.join(rootDir, 'install');
+  this.tarRoot = options.tarballs || path.join(rootDir, 'tarballs');
+
   //
   // Clean the configured temporary build folder, use a 1:1 mapping with the build
   // timeout. Do not run the cleaning if running in development. Default to 15
@@ -80,7 +89,7 @@ function Constructor(app, options) {
   //
   if (app.config.get('env') !== 'development') setInterval(
     this.purge.bind(this),
-    app.config.get('builder').timeout || 15 * 6E4
+    this.timeout
   );
 }
 
@@ -99,7 +108,6 @@ Constructor.prototype.emits = require('emits');
  * @api public
  */
 Constructor.prototype.build = function build(data, done) {
-  const config = this.app.config.get('builder');
   const progress = new Progress(done);
   const constructor = this;
   const app = this.app;
@@ -129,11 +137,9 @@ Constructor.prototype.build = function build(data, done) {
     // processes and should not be used elsewhere to prevent contamination of data.
     //
     const content = constructor.content(data, spec);
-    spec.source = config.source;
-    spec.target = config.target;
+    spec.source = constructor.source;
+    spec.target = constructor.target;
     spec.npm = app.config.get('npm');
-
-    app.contextLog.info('Prepare build for all locales, unpack, npm install, repack for %s', spec.name, spec);
 
     constructor.prepare(spec, content, function (err, paths) {
       if (err) return done(err);
@@ -189,10 +195,6 @@ Constructor.prototype.buildOne = function buildOne(spec, next) {
   const config = app.config.get('builder');
   const progress = new Progress(next);
   const locale = spec.locale;
-  //
-  //
-  // When we are all said and done, end the progress stream
-  //
 
   this._createPaths(spec, (err, paths) => {
     if (err) return progress.end(err);
@@ -215,9 +217,9 @@ Constructor.prototype.buildOne = function buildOne(spec, next) {
       //
       // Set other required bits on spec
       //
-      spec.source = config.source;
+      spec.source = constructor.source;
       spec.type = spec.type || 'webpack';
-      spec.target = config.target;
+      spec.target = constructor.target;
       spec.npm = app.config.get('npm');
       spec.content = paths.tarball;
       app.contextLog.info('building %s with spec', spec.name, spec);
@@ -364,31 +366,12 @@ Constructor.prototype.buildPerLocale = function buildPerLocale(opts, next) {
  * @param {function} fn Completion function
  */
 Constructor.prototype.cleanup = function cleanup(paths, fn) {
+  const { app } = this;
   paths = Array.isArray(paths) ? paths : [paths];
-  async.each(paths, (path, next) => rmrf(path, next), fn);
-};
-
-/**
- * Create the given paths for a tarball download or npm install
- *
- * @param {Object} spec Build specification
- * @param {function} next Completion function
- */
-Constructor.prototype._createPaths = function _paths(spec, next) {
-  const app = this.app;
-  const config = this.app.config.get('builder');
-  const outputRoot = config.install || path.join(os.tmpdir(), 'install');
-  const tarRoot = config.tarballs || path.join(os.tmpdir(), 'tarballs');
-  const uniq = `${encodeURIComponent(spec.name)}-${spec.version}-${spec.env}-${crypto.randomBytes(5).toString('hex')}`;
-  const outputPath = path.join(outputRoot, uniq);
-  const tarball = path.join(tarRoot, uniq + '.tgz');
-
-  app.contextLog.info('Create paths mkdirp: %s', spec.name, spec);
-
-  async.parallel([
-    async.apply(mkdirp, outputRoot),
-    async.apply(mkdirp, tarRoot)
-  ], (err) => next(err, { tarball, outputPath }));
+  async.each(paths, (path, next) => {
+    app.contextLog.info('Cleanup path: %s', path);
+    rmrf(path, next);
+  }, fn);
 };
 
 /**
@@ -401,9 +384,7 @@ Constructor.prototype._createPaths = function _paths(spec, next) {
  * @api public
  */
 Constructor.prototype.prepare = function prepare(spec, content, next) {
-
   const app = this.app;
-
   app.contextLog.info('Prepare build for all locales: %s', spec.name, spec);
 
   this._createPaths(spec, (err, paths) => {
@@ -490,21 +471,21 @@ Constructor.prototype.checkAndDownload = function checkAndDownload(spec, paths, 
  * @param   {Function} next - go to the next step and run builds
  */
 Constructor.prototype.repack = function repack(spec, content, paths, next) {
-  const outputPath = paths.outputPath;
+  const installPath = paths.installPath;
+  const pkgDir = path.join(installPath, 'package');
   const tarball = paths.tarball;
-  const pkgDir = path.join(outputPath, 'package');
   const app = this.app;
 
   app.contextLog.info('Begin npm install & tarball repack', spec.name, spec);
   async.series({
-    unpack: this.unpack.bind(this, { content, outputPath }),
-    install: this.install.bind(this, spec, pkgDir),
+    unpack: this.unpack.bind(this, { content, installPath }),
+    install: this.install.bind(this, spec, installPath),
     pack: this.pack.bind(this, pkgDir, tarball),
     upload: this.upload.bind(this, spec, tarball)
   }, (err) => {
     if (err) return next(err);
 
-    next(null, { install: outputPath, tarball });
+    next(null, { install: installPath, tarball });
   });
 };
 
@@ -540,7 +521,7 @@ Constructor.prototype.unpack = function unpack(opts, next) {
   stream
     .pipe(zlib.Unzip()) // eslint-disable-line new-cap
     .once('error', next)
-    .pipe(tar.extract(opts.outputPath))
+    .pipe(tar.extract(opts.installPath))
     .once('error', next)
     .once('finish', next);
 
@@ -582,18 +563,26 @@ Constructor.prototype.upload = function upload(spec, tarball, next) {
  * Uses the provided environment.
  *
  * @param {Object} spec Spec
- * @param {String} base Path to the package to install
+ * @param {String} installPath os.tmpdir base path to run the install in.
  * @param {Function} next Completion callback.
  * @api public
  */
-Constructor.prototype.install = function install(spec, base, next) {
+Constructor.prototype.install = function install(spec, installPath, next) {
   const npmData = spec.npm;
+  const pkgDir = path.join(installPath, 'package');
 
-  npm.install(assign({
-    base: base,
-    prefix: base,
+  const done = next || function () {};
+  const args = assign({
+    base: pkgDir,
+    prefix: pkgDir,
     env: spec.env
-  }, npmData), next || function () {});
+  }, npmData);
+
+  npm.install({
+    log: this.app.contextLog,
+    installPath,
+    spec
+  }, args, done);
 };
 
 /**
@@ -814,7 +803,6 @@ Constructor.prototype.store = function store(spec, files, callback) {
     rmrf(spec.destDir, function () {});
     app.contextLog.info('Published to BFFS: metadata, compressed and plain content', spec);
     callback();
-
   });
 };
 
@@ -832,27 +820,24 @@ Constructor.prototype.valid = function valid(id) {
 
 /**
  * Helper method that cleans the temporary build folder.
- *
- * @api private
  */
 Constructor.prototype.purge = function purge() {
-  const app = this.app;
+  const { app, target } = this;
   const constructor = this;
-  const config = app.config.get('builder');
-  const age = config.timeout * (config.retries + 2);
+  const age = this.timeout * this.purgeRetries;
 
-  fs.readdir(config.target, function readTarget(error, files) {
+  fs.readdir(target, function readTarget(error, files) {
     if (error || !files) {
-      app.contextLog.error(error);
+      app.contextLog.error('Error reading files to purge from %s: %s', target, error || 'No files found');
       return;
     }
 
     files = files.filter(constructor.valid);
     async.reduce(files, 0, function removeUUIDFolders(i, file, next) {
-      file = path.join(config.target, file);
+      file = path.join(target, file);
 
       fs.stat(file, function getAge(err, stat) {
-        if (err) return void next(err);
+        if (err) return void next(null, i);
 
         //
         // Be defensive and use modified time to determine if the folder is older
@@ -861,9 +846,11 @@ Constructor.prototype.purge = function purge() {
         // millisecond, which could result in a failed build.
         //
         if (Date.now() - age <= new Date(stat.mtime).getTime()) {
+          app.contextLog.info('Skip purge of file: %s', file);
           return next(null, i);
         }
 
+        app.contextLog.info('Purge outdated file: %s', file);
         return void rmrf(file, function removed(rmError) {
           next(rmError, i + 1);
         });
@@ -880,9 +867,36 @@ Constructor.prototype.purge = function purge() {
   });
 };
 
+/**
+ * Create the given paths for a tarball download or npm install
+ *
+ * @param {Object} spec Build specification
+ * @param {function} next Completion function
+ */
+Constructor.prototype._createPaths = function _createPaths(spec) {
+  const { app, installRoot, tarRoot } = this;
+  const uniq = `${encodeURIComponent(spec.name)}-${spec.version}-${spec.env}-${crypto.randomBytes(5).toString('hex')}`;
+  const installPath = path.join(this.installRoot, uniq);
+  const tarball = path.join(this.tarRoot, uniq + '.tgz');
+  const paths = { installPath, tarball };
+
+  app.contextLog.info('Create paths for spec: %s', spec.name, spec, paths);
+  app.contextLog.info('Create paths mkdirp: %s', spec.name, spec);
+  async.parallel([
+    async.apply(mkdirp, this.installRoot),
+    async.apply(mkdirp, this.tarRoot)
+  ], (err) => next(err, { tarball, installPath }));
+};
+
+/**
+ * Executes the worker for `spec.type` including setting the appropriate
+ * environment variables.
+ *
+ * @param {Object} spec Build specification
+ * @param {function} next Completion function
+ */
 Constructor.prototype._runBuild = function _build(spec, callback) {
   const app = this.app;
-
   const opts = assign({}, spec, {
     processEnv: assign({}, process.env, {
       NODE_ENV: fullEnvs.get(spec.env),
@@ -890,6 +904,7 @@ Constructor.prototype._runBuild = function _build(spec, callback) {
       WRHS_LOCALE: spec.locale
     })
   });
+
   app.contextLog.info('Building %s with %s with locale %s', spec.name, spec.type, spec.locale);
   const worker = workers[spec.type];
   worker(opts, callback);
@@ -900,7 +915,6 @@ Constructor.prototype._runBuild = function _build(spec, callback) {
 //
 module.exports = function preboot(app, options, done) {
   const config = app.config.get('builder');
-
   app.construct = new Constructor(app, config);
   done();
 };

--- a/lib/constructor/index.js
+++ b/lib/constructor/index.js
@@ -79,8 +79,8 @@ function Constructor(app, options) {
   this.source = options.source;
   this.target = options.target;
   this.rootDir = options.target || os.tmpdir();
-  this.installRoot = options.install || path.join(rootDir, 'install');
-  this.tarRoot = options.tarballs || path.join(rootDir, 'tarballs');
+  this.installRoot = options.install || path.join(this.rootDir, 'install');
+  this.tarRoot = options.tarballs || path.join(this.rootDir, 'tarballs');
 
   //
   // Clean the configured temporary build folder, use a 1:1 mapping with the build
@@ -191,9 +191,8 @@ Constructor.prototype.build = function build(data, done) {
  */
 Constructor.prototype.buildOne = function buildOne(spec, next) {
   const app = this.app;
-  const constructor = this;
-  const config = app.config.get('builder');
   const progress = new Progress(next);
+  const constructor = this;
   const locale = spec.locale;
 
   this._createPaths(spec, (err, paths) => {
@@ -865,19 +864,19 @@ Constructor.prototype.purge = function purge() {
  * @param {Object} spec Build specification
  * @param {function} next Completion function
  */
-Constructor.prototype._createPaths = function _createPaths(spec) {
+Constructor.prototype._createPaths = function _createPaths(spec, next) {
   const { app, installRoot, tarRoot } = this;
   const uniq = `${encodeURIComponent(spec.name)}-${spec.version}-${spec.env}-${crypto.randomBytes(5).toString('hex')}`;
-  const installPath = path.join(this.installRoot, uniq);
-  const tarball = path.join(this.tarRoot, uniq + '.tgz');
+  const installPath = path.join(installRoot, uniq);
+  const tarball = path.join(tarRoot, uniq + '.tgz');
   const paths = { installPath, tarball };
 
   app.contextLog.info('Create paths for spec: %s', spec.name, spec, paths);
-  app.contextLog.info('Create paths mkdirp: %s', spec.name, spec);
+
   async.parallel([
-    async.apply(mkdirp, this.installRoot),
-    async.apply(mkdirp, this.tarRoot)
-  ], (err) => next(err, { tarball, installPath }));
+    async.apply(mkdirp, installRoot),
+    async.apply(mkdirp, tarRoot)
+  ], (err) => next(err, paths));
 };
 
 /**
@@ -885,7 +884,7 @@ Constructor.prototype._createPaths = function _createPaths(spec) {
  * environment variables.
  *
  * @param {Object} spec Build specification
- * @param {function} next Completion function
+ * @param {function} callback Completion function
  */
 Constructor.prototype._runBuild = function _build(spec, callback) {
   const app = this.app;

--- a/lib/constructor/index.js
+++ b/lib/constructor/index.js
@@ -298,14 +298,6 @@ Constructor.prototype.buildPerLocale = function buildPerLocale(opts, next) {
       next();
     }
 
-    app.contextLog.info('Start fresh build', {
-      locale: locale,
-      name: spec.name,
-      version: spec.version,
-      env: spec.env,
-      id: id
-    });
-
     //
     // Launch the build process with the specifications and attach
     // a supervisor to communicate all events back to the developer.

--- a/lib/constructor/npm/index.js
+++ b/lib/constructor/npm/index.js
@@ -1,37 +1,47 @@
 'use strict';
 
+const path = require('path');
+const fs = require('fs');
 const spawn = require('child_process').spawn;
 const once = require('one-time');
 const bl = require('bl');
 const npm = require.resolve('./npm');
 
-exports.install = function (options, callback) {
+exports.install = function (opts, args, callback) {
+  const { app, spec, installPath } = opts;
   const done = once(callback);
   const env = Object.keys(process.env).reduce((acc, key) => {
     acc[key] = process.env[key];
     return acc;
   }, {});
 
-  let errorLogs = '';
-  env.NODE_ENV = ~['prod', 'latest'].indexOf(options.env) ? 'production' : 'development';
+  env.NODE_ENV = ~['prod', 'latest'].indexOf(options.env)
+    ? 'production'
+    : 'development';
 
-  // Danger zone
+  const logs = {
+    stdout: path.join(installPath, 'stdout.log'),
+    stderr: path.join(installPath, 'stderr.log')
+  };
+
+  app.contextLog('npm logs available for spec: %s', spec.name, spec, logs);
+
+  // Danger zone - spawn the child process running ./npm.js
   const child = spawn(process.execPath, ['--max_old_space_size=8192', npm]
-    .filter(Boolean).concat(cliArgs(options)).concat(['install']), {
+    .filter(Boolean).concat(cliArgs(args)).concat(['install']), {
     env: env
   });
 
   child.on('error', done);
-
-  child.stderr.pipe(bl((err, body) => {
-    /* eslint consistent-return: 0 */
-    if (err) return done(err);
-    errorLogs = body.toString();
-  }));
+  child.stderr.pipe(fs.createWriteStream(logs.stderr));
+  child.stdout.pipe(fs.createWriteStream(logs.stdout));
 
   child.on('close', (code) => {
     if (code !== 0) {
-      return done(new Error(`npm exited with code ${code} ${errorLogs}`));
+      return fs.readFile(logs.stderr, 'utf8', function (err, text) {
+        const msg = text || (err && err.message) || `Could not read ${installPath/stderr.log}`;
+        done(new Error(`npm exited with code ${code} ${msg}`));
+      });
     }
 
     return done();

--- a/lib/constructor/npm/index.js
+++ b/lib/constructor/npm/index.js
@@ -50,7 +50,7 @@ exports.install = function (opts, args, callback) {
   child.on('close', (code) => {
     if (code !== 0) {
       return fs.readFile(logs.stderr, 'utf8', function (err, text) {
-        const msg = text || (err && err.message) || `Could not read ${installPath / logs.stderr}`;
+        const msg = text || (err && err.message) || `Could not read ${logs.stderr}`;
         done(new Error(`npm exited with code ${code} ${msg}`));
       });
     }

--- a/lib/constructor/npm/index.js
+++ b/lib/constructor/npm/index.js
@@ -4,18 +4,17 @@ const path = require('path');
 const fs = require('fs');
 const spawn = require('child_process').spawn;
 const once = require('one-time');
-const bl = require('bl');
 const npm = require.resolve('./npm');
 
 exports.install = function (opts, args, callback) {
-  const { app, spec, installPath } = opts;
+  const { log, spec, installPath } = opts;
   const done = once(callback);
   const env = Object.keys(process.env).reduce((acc, key) => {
     acc[key] = process.env[key];
     return acc;
   }, {});
 
-  env.NODE_ENV = ~['prod', 'latest'].indexOf(options.env)
+  env.NODE_ENV = ~['prod', 'latest'].indexOf(spec.env)
     ? 'production'
     : 'development';
 
@@ -24,7 +23,7 @@ exports.install = function (opts, args, callback) {
     stderr: path.join(installPath, 'stderr.log')
   };
 
-  app.contextLog('npm logs available for spec: %s', spec.name, spec, logs);
+  log.info('npm logs available for spec: %s', spec.name, spec, logs);
 
   // Danger zone - spawn the child process running ./npm.js
   const child = spawn(process.execPath, ['--max_old_space_size=8192', npm]
@@ -39,7 +38,7 @@ exports.install = function (opts, args, callback) {
   child.on('close', (code) => {
     if (code !== 0) {
       return fs.readFile(logs.stderr, 'utf8', function (err, text) {
-        const msg = text || (err && err.message) || `Could not read ${installPath/stderr.log}`;
+        const msg = text || (err && err.message) || `Could not read ${installPath / logs.stderr}`;
         done(new Error(`npm exited with code ${code} ${msg}`));
       });
     }

--- a/lib/constructor/npm/index.js
+++ b/lib/constructor/npm/index.js
@@ -31,9 +31,21 @@ exports.install = function (opts, args, callback) {
     env: env
   });
 
+  function onFileError(type, path) {
+    return (err) => {
+      log.error(`npm install ${type} filestream error for ${path}`, {
+        message: err.message,
+        stack: err.stack,
+        code: err.code
+      });
+    };
+  }
+
   child.on('error', done);
-  child.stderr.pipe(fs.createWriteStream(logs.stderr));
-  child.stdout.pipe(fs.createWriteStream(logs.stdout));
+  child.stderr.pipe(fs.createWriteStream(logs.stderr))
+    .on('error', onFileError('stderr', logs.stderr));
+  child.stdout.pipe(fs.createWriteStream(logs.stdout))
+    .on('error', onFileError('stdout', logs.stdout));
 
   child.on('close', (code) => {
     if (code !== 0) {

--- a/test/lib/constructor/index.test.js
+++ b/test/lib/constructor/index.test.js
@@ -276,7 +276,7 @@ describe('Constructor', function () {
       fs.mkdir(path.join(config.target, uuid), function (error) {
         if (error) return done(error);
 
-        construct.app.config.set('builder:timeout', -1);
+        construct.timeout = -1;
         construct.purge();
 
         return construct.once('purge', function (err, n) {
@@ -286,7 +286,7 @@ describe('Constructor', function () {
           fs.readdir(config.target, function (e, files) {
             assume(e).to.be.falsey();
             assume(files.filter(construct.valid)).to.have.length(0);
-            construct.app.config.set('builder:timeout', timeout);
+            construct.timeout = timeout;
 
             done();
           });


### PR DESCRIPTION
- [api] Better logging around file purging.
- [refactor] Remove additional calls to `app.config.get('builder')` since that is passed in the preboot.
- [refactor] Setup additional state in the constructor instead of on each build.
- [refactor] Move private methods to the bottom of files.
- [refactor] Rename outputPath to installPath.
- [refactor api] Pass opts and args to `./lib/constructor/npm/index.js`.
- [api] Use opts passed to npm to specify log files for `stdout.log` and `stderr.log`.
- [api] Slightly increase the magic number of additional built-in retries before purging.
- [refactor] Move fitting code into `lib/constructor/fitting.js`.

The `stdout.log` and `stderr.log` files generated are guaranteed to be cleaned up along with the other build files when it is complete. While in process, however, they represent a tailable source of debugging.

