### PR TITLE
Be more verbose, but also less verbose.

### DIFF
--- a/lib/constructor/npm/index.js
+++ b/lib/constructor/npm/index.js
@@ -23,11 +23,11 @@ exports.install = function (opts, args, callback) {
     stderr: path.join(installPath, 'stderr.log')
   };
 
-  log.info('npm logs available for spec: %s', spec.name, spec, logs);
+  log.info('npm logs available for spec: %s@%s %j', spec.name, spec.version, logs);
 
   // Danger zone - spawn the child process running ./npm.js
   const child = spawn(process.execPath, ['--max_old_space_size=8192', npm]
-    .filter(Boolean).concat(cliArgs(args)).concat(['install']), {
+    .filter(Boolean).concat(cliArgs(args)).concat(['install', '--log-level=http']), {
     env: env
   });
 

--- a/lib/constructor/npm/index.js
+++ b/lib/constructor/npm/index.js
@@ -23,7 +23,7 @@ exports.install = function (opts, args, callback) {
     stderr: path.join(installPath, 'stderr.log')
   };
 
-  log.info('npm logs available for spec: %s@%s %j', spec.name, spec.version, logs);
+  log.info('npm logs available for spec: %s@%s', spec.name, spec.version, logs);
 
   // Danger zone - spawn the child process running ./npm.js
   const child = spawn(process.execPath, ['--max_old_space_size=8192', npm]

--- a/lib/constructor/npm/index.js
+++ b/lib/constructor/npm/index.js
@@ -27,7 +27,7 @@ exports.install = function (opts, args, callback) {
 
   // Danger zone - spawn the child process running ./npm.js
   const child = spawn(process.execPath, ['--max_old_space_size=8192', npm]
-    .filter(Boolean).concat(cliArgs(args)).concat(['install', '--log-level=http']), {
+    .filter(Boolean).concat(cliArgs(args)).concat(['install']), {
     env: env
   });
 

--- a/lib/constructor/npm/npm.js
+++ b/lib/constructor/npm/npm.js
@@ -19,6 +19,7 @@ function parse(opts) {
   //
   if (opts.prefix) config.prefix = opts.prefix;
   config.production = false;
+  config.loglevel = 'http';
 
   return config;
 }


### PR DESCRIPTION
This PR:

- Gives a better log message for `npm logs`.
- Makes the logs written from `npm` more verbose using `--loglevel=http`.