### PR TITLE
Default this.target and use it as the default for this.rootDir.

### DIFF
--- a/lib/constructor/index.js
+++ b/lib/constructor/index.js
@@ -72,8 +72,8 @@ function Constructor(app, options) {
   this.purgeRetries = (options.retries || 0) + 5;
 
   this.source = options.source;
-  this.target = options.target;
-  this.rootDir = options.target || os.tmpdir();
+  this.target = options.target || os.tmpdir();
+  this.rootDir = options.target || this.target;
   this.installRoot = options.install || path.join(this.rootDir, 'install');
   this.tarRoot = options.tarballs || path.join(this.rootDir, 'tarballs');
 


### PR DESCRIPTION
```
 fs.js:897
   binding.readdir(pathModule._makeLong(path), options.encoding, req);
           ^
 
 TypeError: path must be a string or Buffer
     at Object.fs.readdir (fs.js:897:11)
     at Constructor.purge (carpenterd/lib/constructor/index.js:780:6)
     at ontimeout (timers.js:475:11)
     at tryOnTimeout (timers.js:310:5)
     at Timer.listOnTimeout (timers.js:270:5)
```