### PR TITLE
Status timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+- Add timing information to status nsq messages
+- Add additional status nsq messages for unpack, pack, upload
+- Allow for `npm install` retries in nsq status messages
+
 ### 2.3.1
 
 - [#33] Default `this.target` and use it as the default for `this.rootDir`.

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -123,7 +123,6 @@ Constructor.prototype.build = function build(data, done) {
     name: data.name
   });
 
-
   constructor.specs(data, function specifications(error, spec) {
     if (error) {
       return void progress.fail(error);

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -179,7 +179,7 @@ Constructor.prototype.build = function build(data, done) {
           locale,
           spec
         }, next);
-      }, statusWriter.writeEndWrap(statusKey, finish));
+      }, statusWriter.writeWrap(statusKey, finish));
     });
   });
 
@@ -512,7 +512,7 @@ Constructor.prototype.repack = function repack(spec, content, paths, statusWrite
  */
 Constructor.prototype.pack = function pack(source, target, statusWriter, next) {
   const statusKey = 'packing';
-  const done = once(statusWriter.writeEndWrap(statusKey, next));
+  const done = once(statusWriter.writeWrap(statusKey, next));
   statusWriter.writeStart(statusKey);
   tar.pack(source)
     .once('error', done)
@@ -534,7 +534,7 @@ Constructor.prototype.unpack = function unpack(opts, next) {
   const { content, installPath, statusWriter } = opts;
   const stream = through();
   const statusKey = 'unpacking';
-  const done = once(statusWriter.writeEndWrap(statusKey, next));
+  const done = once(statusWriter.writeWrap(statusKey, next));
   statusWriter.writeStart(statusKey);
 
   stream
@@ -567,7 +567,7 @@ Constructor.prototype.upload = function upload(spec, tarball, statusWriter, next
 
   const logOpts = assign({ tarball }, spec);
   this.cdnup.upload(tarball, filePath, (err, url) => {
-    statusWriter.writeStandardEnd(statusKey, err);
+    statusWriter.writeMaybeError(statusKey, err);
 
     if (err) {
       return app.contextLog.error('Failed to upload tarball for package',
@@ -606,7 +606,7 @@ Constructor.prototype.install = function install(spec, installPath, statusWriter
       spec,
       statusWriter
     }, next);
-  }, statusWriter.writeEndWrap(statusKey, done));
+  }, statusWriter.writeWrap(statusKey, done));
 
 };
 

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -506,6 +506,7 @@ Constructor.prototype.repack = function repack(spec, content, paths, statusWrite
  *
  * @param {String} source Source directory
  * @param {String} target Target directory
+ * @param {StatusWriter} statusWriter The writer for the status-api
  * @param {Function} next Completion callback.
  * @api public
  */
@@ -551,6 +552,7 @@ Constructor.prototype.unpack = function unpack(opts, next) {
  *
  * @param {Object} spec Defines this package
  * @param {String} tarball Path to tarball
+ * @param {StatusWriter} statusWriter The writer for the status-api
  * @param {Function} next Optional completion callback.
  *
  * @returns {undefined} Nothing special

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -114,6 +114,7 @@ Constructor.prototype.build = function build(data, done) {
   }, done);
   const constructor = this;
   const app = this.app;
+  const { statusWriter } = progress;
 
   //
   // Compile build specifications from the data.
@@ -122,12 +123,13 @@ Constructor.prototype.build = function build(data, done) {
     name: data.name
   });
 
+
   constructor.specs(data, function specifications(error, spec) {
     if (error) {
       return void progress.fail(error);
     }
 
-    progress.statusWriter.metadata = spec;
+    statusWriter.metadata = spec;
 
     //
     // No-build flag was added to the package.json to indicate there are no build
@@ -146,7 +148,7 @@ Constructor.prototype.build = function build(data, done) {
     spec.source = constructor.source;
     spec.target = constructor.target;
 
-    constructor.prepare(spec, content, progress.statusWriter, function (err, paths) {
+    constructor.prepare(spec, content, statusWriter, function (err, paths) {
       if (err) return done(err);
 
       //
@@ -154,6 +156,7 @@ Constructor.prototype.build = function build(data, done) {
       // contains the `npm.install`
       //
       app.contextLog.info('building %s with spec', spec.name, spec);
+      const statusKey = 'Queueing all builds';
 
       //
       //
@@ -168,14 +171,15 @@ Constructor.prototype.build = function build(data, done) {
           app.contextLog.info('Finished build for %s', spec.name, spec);
         });
       }
-      progress.statusWriter.write(`Queuing all builds`);
+
+      statusWriter.writeStart(statusKey);
       return void async.each(spec.locales, (locale, next) => {
         constructor.buildPerLocale({
           progress,
           locale,
           spec
         }, next);
-      }, finish);
+      }, statusWriter.writeEndWrap(statusKey, finish));
     });
   });
 
@@ -486,10 +490,10 @@ Constructor.prototype.repack = function repack(spec, content, paths, statusWrite
 
   app.contextLog.info('Begin npm install & tarball repack', spec.name, spec);
   async.series({
-    unpack: this.unpack.bind(this, { content, installPath }),
+    unpack: this.unpack.bind(this, { content, installPath, statusWriter }),
     install: this.install.bind(this, spec, installPath, statusWriter),
-    pack: this.pack.bind(this, pkgDir, tarball),
-    upload: this.upload.bind(this, spec, tarball)
+    pack: this.pack.bind(this, pkgDir, tarball, statusWriter),
+    upload: this.upload.bind(this, spec, tarball, statusWriter)
   }, (err) => {
     if (err) return next(err);
 
@@ -505,8 +509,10 @@ Constructor.prototype.repack = function repack(spec, content, paths, statusWrite
  * @param {Function} next Completion callback.
  * @api public
  */
-Constructor.prototype.pack = function pack(source, target, next) {
-  const done = once(next);
+Constructor.prototype.pack = function pack(source, target, statusWriter, next) {
+  const statusKey = 'packing';
+  const done = once(statusWriter.writeEndWrap(statusKey, next));
+  statusWriter.writeStart(statusKey);
   tar.pack(source)
     .once('error', done)
     .pipe(zlib.Gzip()) // eslint-disable-line new-cap
@@ -524,16 +530,20 @@ Constructor.prototype.pack = function pack(source, target, next) {
  * @api public
  */
 Constructor.prototype.unpack = function unpack(opts, next) {
+  const { content, installPath, statusWriter } = opts;
   const stream = through();
+  const statusKey = 'unpacking';
+  const done = once(statusWriter.writeEndWrap(statusKey, next));
+  statusWriter.writeStart(statusKey);
 
   stream
     .pipe(zlib.Unzip()) // eslint-disable-line new-cap
-    .once('error', next)
-    .pipe(tar.extract(opts.installPath))
-    .once('error', next)
-    .once('finish', next);
+    .once('error', done)
+    .pipe(tar.extract(installPath))
+    .once('error', done)
+    .once('finish', done);
 
-  stream.end(new Buffer(opts.content, 'base64'));
+  stream.end(new Buffer(content, 'base64'));
 };
 
 /**
@@ -546,13 +556,17 @@ Constructor.prototype.unpack = function unpack(opts, next) {
  * @returns {undefined} Nothing special
  * @api public
  */
-Constructor.prototype.upload = function upload(spec, tarball, next) {
+Constructor.prototype.upload = function upload(spec, tarball, statusWriter, next) {
   if (!this.cdnup) return setImmediate(next);
   const app = this.app;
+  const statusKey = 'uploading';
+  statusWriter.writeStart(statusKey);
   const filePath = `${encodeURIComponent(spec.name)}-${spec.version}.tgz`;
 
   const logOpts = assign({ tarball }, spec);
   this.cdnup.upload(tarball, filePath, (err, url) => {
+    statusWriter.writeStandardEnd(statusKey, err);
+
     if (err) {
       return app.contextLog.error('Failed to upload tarball for package',
         assign({ error: err.message }, logOpts));
@@ -577,7 +591,9 @@ Constructor.prototype.install = function install(spec, installPath, statusWriter
   const pkgDir = path.join(installPath, 'package');
 
   const done = fn || function () {};
+  const statusKey = 'npm install-all';
 
+  statusWriter.writeStart(statusKey);
   const op = retry.op(this.retry);
   op.attempt(next => {
     npm.install({
@@ -588,7 +604,7 @@ Constructor.prototype.install = function install(spec, installPath, statusWriter
       spec,
       statusWriter
     }, next);
-  }, done);
+  }, statusWriter.writeEndWrap(statusKey, done));
 
 };
 

--- a/lib/construct/npm/index.js
+++ b/lib/construct/npm/index.js
@@ -40,7 +40,7 @@ exports.install = function (opts, callback) {
         stack: err.stack,
         code: err.code
       });
-      statusWriter.write(`ERROR: 'npm install' failed.\nmessage: ${err.message}\nstack: ${err.stack}\ncode: ${err.code}`);
+      statusWriter.write(null, `ERROR: 'npm install' failed.\nmessage: ${err.message}\nstack: ${err.stack}\ncode: ${err.code}`);
     };
   }
 
@@ -56,7 +56,7 @@ exports.install = function (opts, callback) {
         const msg = text || (err && err.message) || `Could not read ${logs.stderr}`;
         // Intentionally not an Error event here as it'll get retried externally,
         // only if all attempts fail should it be a status error
-        statusWriter.writeEnd(statusKey, {
+        statusWriter.write(statusKey, {
           message: `ERROR: 'npm install' attempt exited with code: ${code}.`,
           details: msg
         });
@@ -64,7 +64,7 @@ exports.install = function (opts, callback) {
       });
     }
 
-    statusWriter.writeEnd(statusKey, `'npm install' attempt completed successfully`);
+    statusWriter.write(statusKey, `'npm install' attempt completed successfully`);
     return done();
   });
 

--- a/lib/construct/npm/index.js
+++ b/lib/construct/npm/index.js
@@ -7,6 +7,7 @@ const once = require('one-time');
 const npm = path.join(require.resolve('npm'), '..', '..', 'bin', 'npm-cli.js');
 
 const assign = Object.assign;
+const statusKey = 'npm install';
 
 exports.install = function (opts, callback) {
   const { log, spec, installPath, pkgDir, userconfig, statusWriter } = opts;
@@ -23,7 +24,7 @@ exports.install = function (opts, callback) {
   };
 
   log.info('npm logs available for spec: %s@%s', spec.name, spec.version, logs);
-  statusWriter.write(`'npm install' starting`);
+  statusWriter.writeStart(statusKey, `'npm install' attempt starting`);
 
   // Danger zone - spawn the child process running ./npm.js
   const child = spawn(process.execPath, ['--max_old_space_size=8192', npm]
@@ -53,15 +54,17 @@ exports.install = function (opts, callback) {
     if (code !== 0) {
       return fs.readFile(logs.stderr, 'utf8', function (err, text) {
         const msg = text || (err && err.message) || `Could not read ${logs.stderr}`;
-        statusWriter.writeError({
-          message: `ERROR: 'npm install' exited with code: ${code}.`,
+        // Intentionally not an Error event here as it'll get retried externally,
+        // only if all attempts fail should it be a status error
+        statusWriter.writeEnd(statusKey, {
+          message: `ERROR: 'npm install' attempt exited with code: ${code}.`,
           details: msg
         });
         done(new Error(`npm exited with code ${code} ${msg}`));
       });
     }
 
-    statusWriter.write(`'npm install' completed successfully`);
+    statusWriter.writeEnd(statusKey, `'npm install' attempt completed successfully`);
     return done();
   });
 

--- a/lib/construct/progress.js
+++ b/lib/construct/progress.js
@@ -183,7 +183,7 @@ Progress.prototype.write = function write(data, id, options = {}) {
   }
 
   if ((!options || !options.skipNsq)
-    && data.message !== 'start') this.statusWriter.write(data);
+    && data.message !== 'start') this.statusWriter.write(null, data);
 
   return this;
 };

--- a/lib/construct/status-writer.js
+++ b/lib/construct/status-writer.js
@@ -1,6 +1,11 @@
 const { performance } = require('perf_hooks');
 const nsqStream = require('nsq-stream');
 
+const eventTypes = {
+  error: 'error',
+  default: 'event'
+};
+
 /**
  * Writes to the status-api NSQ topic
  *
@@ -36,33 +41,7 @@ class StatusWriter {
    */
   writeStart(key, data) {
     this.timings.set(key, performance.now());
-    this.write(data || `'${key}' starting`);
-  }
-
-  /**
-   * Writes a message to the status API nsq stream, stops the performance
-   * timer and adds the timing information to the status message
-   *
-   * @param {String} key The key used to when starting the performance timer
-   * @param {Object|String} data Data for the event to write, an object or
-   * a string to be used for the message.
-   * @public
-   */
-  writeEnd(key, data) {
-    this.write(this.getDataWithTiming(key, data || `'${key}' completed successfully`));
-  }
-
-  /**
-   * Writes an error status to the status API nsq stream, stops the performance
-   * timer and adds the timing information to the status message
-   *
-   * @param {String} key The key used to when starting the performance timer
-   * @param {Object|String} data Data for the event to write, an object or
-   * a string to be used for the message.
-   * @public
-   */
-  writeErrorEnd(key, data) {
-    this.writeError(this.getDataWithTiming(key, data));
+    this.write(null, data || `'${key}' starting`);
   }
 
   /**
@@ -76,16 +55,16 @@ class StatusWriter {
    * this to be written as an error event.
    * @public
    */
-  writeStandardEnd(key, err) {
+  writeMaybeError(key, err) {
     if (err) {
-      this.writeErrorEnd(key, {
+      this.writeInternal(key, {
         message: `ERROR: '${key}' exited with code: ${err}.`,
         details: err
-      });
+      }, eventTypes.error);
       return;
     }
 
-    this.writeEnd(key);
+    this.write(key);
   }
 
   /**
@@ -96,38 +75,31 @@ class StatusWriter {
    * @returns {Function} A new callback function that wraps the given callback.
    * @public
    */
-  writeEndWrap(key, done) {
+  writeWrap(key, done) {
     return (err, data) => {
-      this.writeStandardEnd(key, err);
+      this.writeMaybeError(key, err);
       done(err, data);
     };
   }
 
   /**
-   * Stops the peformance timer and returns the data with timing information attached.
+   * Stops the performance timer and returns the timing information.
    *
    * @param {String} key The key used when starting the performance timer
-   * @param {Object|String} data Data for the event to write, an object or
-   * a string to be used for the message.
-   * @returns {Object} The data with performance timings attached
+   * @returns {Object} The performance timing
+   * @private
    */
-  getDataWithTiming(key, data) {
+  getTiming(key) {
     const timing = performance.now() - this.timings.get(key);
     this.timings.delete(key);
-
-    if (typeof data === 'string') {
-      return { message: data, timing };
-    }
-
-    return {
-      ...data,
-      timing
-    };
+    return timing;
   }
 
   /**
    * Writes an event to the status API nsq stream.
    *
+   * @param {String?} key The key used when starting the performance timer.
+   * If providing, timing information will be added to the status message
    * @param {Object|String} data Data for the event to write, an object or a string to be used for the message
    * @param {String} [data.locale] The locale for the build
    * @param {String} [data.message] The human-readable message being written
@@ -135,39 +107,33 @@ class StatusWriter {
    * @returns {undefined} Nothing whatsoever
    * @public
    */
-  write(data) {
-    if (!data || !this._isWriteable()) {
+  write(key, data) {
+    if (!this._isWriteable()) {
       return;
     }
 
-    if (typeof data === 'string') {
-      data = { message: data };
+    if (key && !data) {
+      data = { message: `'${key}' completed successfully` };
     }
 
-    // Intercept the internal error messages so we send a proper error message
-    // over NSQ
-    if (data.event && data.event === 'error') {
-      return void this.writeError(data);
-    }
-
-    const payload = {
-      message: data.message,
-      locale: data.locale,
-      details: data.details,
-      timing: data.timing
-    };
-
-    this.nsqStream.write(this._makeSpec(payload));
-    console.log('!!! Write: ', payload);
+    this.writeInternal(key, data,
+      data && data.event === 'error' ? eventTypes.error : eventTypes.default);
   }
 
   /**
-   * Writes an error status to the status API nsq stream
+   * Writes an event to the status API nsq stream.
    *
-   * @param {Object|String} data The error message or object describing it
-   * @public
+   * @param {String?} key The key used when starting the performance timer.
+   * If providing, timing information will be added to the status message
+   * @param {Object|String} data Data for the event to write, an object or a string to be used for the message
+   * @param {String} [data.locale] The locale for the build
+   * @param {String} [data.message] The human-readable message being written
+   * @param {Number} [data.progress] The calculated progress for this build
+   * @param {String} eventType The eventType for the status
+   * @returns {undefined} Nothing whatsoever
+   * @private
    */
-  writeError(data) {
+  writeInternal(key, data, eventType) {
     if (!data || !this._isWriteable()) {
       return;
     }
@@ -177,15 +143,17 @@ class StatusWriter {
     }
 
     const payload = {
-      eventType: 'error',
+      eventType,
       message: data.message,
       locale: data.locale,
-      details: data.details,
-      timing: data.timing
+      details: data.details
     };
 
+    if (key) {
+      payload.timing = this.getTiming(key);
+    }
+
     this.nsqStream.write(this._makeSpec(payload));
-    console.log('!!! Error: ', payload);
   }
 
   /**
@@ -227,7 +195,7 @@ class StatusWriter {
   _makeSpec(otherFields = {}) {
     const { name, env, version, type: buildType } = this.metadata || {};
     return {
-      eventType: 'event',
+      eventType: eventTypes.default,
       name,
       env,
       version,

--- a/lib/construct/status-writer.js
+++ b/lib/construct/status-writer.js
@@ -1,3 +1,4 @@
+const { performance } = require('perf_hooks');
 const nsqStream = require('nsq-stream');
 
 /**
@@ -21,6 +22,107 @@ class StatusWriter {
     this.nsqStream = nsq.writer && nsq.topic && nsqStream.createWriteStream(nsq.writer, nsq.topic);
     this.metadata = opts && opts.metadata || {};
     this.buildsCompleted = 0;
+    this.timings = new Map();
+  }
+
+  /**
+   * Writes a message to the status API nsq stream, also starts a performance
+   * timer to track duration for some event
+   *
+   * @param {String} key The key to use to start a new performance timer
+   * @param {Object|String?} data Data for the event to write, an object or a
+   * string to be used for the message, if none is provided, one will be constructed based off the key
+   * @public
+   */
+  writeStart(key, data) {
+    this.timings.set(key, performance.now());
+    this.write(data || `'${key}' starting`);
+  }
+
+  /**
+   * Writes a message to the status API nsq stream, stops the performance
+   * timer and adds the timing information to the status message
+   *
+   * @param {String} key The key used to when starting the performance timer
+   * @param {Object|String} data Data for the event to write, an object or
+   * a string to be used for the message.
+   * @public
+   */
+  writeEnd(key, data) {
+    this.write(this.getDataWithTiming(key, data || `'${key}' completed successfully`));
+  }
+
+  /**
+   * Writes an error status to the status API nsq stream, stops the performance
+   * timer and adds the timing information to the status message
+   *
+   * @param {String} key The key used to when starting the performance timer
+   * @param {Object|String} data Data for the event to write, an object or
+   * a string to be used for the message.
+   * @public
+   */
+  writeErrorEnd(key, data) {
+    this.writeError(this.getDataWithTiming(key, data));
+  }
+
+  /**
+   * Writes a message to the status API nsq stream, stops the performance
+   * timer and adds the timing information to the status message. The
+   * status message will follow a standard format. The type of status
+   * message written will be based on whether an error was passed.
+   *
+   * @param {String} key The key used to when starting the performance timer
+   * @param {Error?} err The error (if any). Passing an error will cause
+   * this to be written as an error event.
+   * @public
+   */
+  writeStandardEnd(key, err) {
+    if (err) {
+      this.writeErrorEnd(key, {
+        message: `ERROR: '${key}' exited with code: ${err}.`,
+        details: err
+      });
+      return;
+    }
+
+    this.writeEnd(key);
+  }
+
+  /**
+   * Wraps a callback function with a status writer that will complete a performance timer
+   *
+   * @param {String} key The key used when starting the performance timer
+   * @param {Function} done The function to call after writing the event
+   * @returns {Function} A new callback function that wraps the given callback.
+   * @public
+   */
+  writeEndWrap(key, done) {
+    return (err, data) => {
+      this.writeStandardEnd(key, err);
+      done(err, data);
+    };
+  }
+
+  /**
+   * Stops the peformance timer and returns the data with timing information attached.
+   *
+   * @param {String} key The key used when starting the performance timer
+   * @param {Object|String} data Data for the event to write, an object or
+   * a string to be used for the message.
+   * @returns {Object} The data with performance timings attached
+   */
+  getDataWithTiming(key, data) {
+    const timing = performance.now() - this.timings.get(key);
+    this.timings.delete(key);
+
+    if (typeof data === 'string') {
+      return { message: data, timing };
+    }
+
+    return {
+      ...data,
+      timing
+    };
   }
 
   /**
@@ -51,10 +153,12 @@ class StatusWriter {
     const payload = {
       message: data.message,
       locale: data.locale,
-      details: data.details
+      details: data.details,
+      timing: data.timing
     };
 
     this.nsqStream.write(this._makeSpec(payload));
+    console.log('!!! Write: ', payload);
   }
 
   /**
@@ -76,10 +180,12 @@ class StatusWriter {
       eventType: 'error',
       message: data.message,
       locale: data.locale,
-      details: data.details
+      details: data.details,
+      timing: data.timing
     };
 
     this.nsqStream.write(this._makeSpec(payload));
+    console.log('!!! Error: ', payload);
   }
 
   /**

--- a/lib/construct/status-writer.js
+++ b/lib/construct/status-writer.js
@@ -57,10 +57,11 @@ class StatusWriter {
    */
   writeMaybeError(key, err) {
     if (err) {
-      this.writeInternal(key, {
+      this.write(key, {
         message: `ERROR: '${key}' exited with code: ${err}.`,
-        details: err
-      }, eventTypes.error);
+        details: err,
+        event: eventTypes.error
+      });
       return;
     }
 
@@ -116,25 +117,7 @@ class StatusWriter {
       data = { message: `'${key}' completed successfully` };
     }
 
-    this.writeInternal(key, data,
-      data && data.event === 'error' ? eventTypes.error : eventTypes.default);
-  }
-
-  /**
-   * Writes an event to the status API nsq stream.
-   *
-   * @param {String?} key The key used when starting the performance timer.
-   * If providing, timing information will be added to the status message
-   * @param {Object|String} data Data for the event to write, an object or a string to be used for the message
-   * @param {String} [data.locale] The locale for the build
-   * @param {String} [data.message] The human-readable message being written
-   * @param {Number} [data.progress] The calculated progress for this build
-   * @param {String} eventType The eventType for the status
-   * @returns {undefined} Nothing whatsoever
-   * @private
-   */
-  writeInternal(key, data, eventType) {
-    if (!data || !this._isWriteable()) {
+    if (!data) {
       return;
     }
 
@@ -143,7 +126,7 @@ class StatusWriter {
     }
 
     const payload = {
-      eventType,
+      eventType: data.event === 'error' ? eventTypes.error : eventTypes.default,
       message: data.message,
       locale: data.locale,
       details: data.details

--- a/package-lock.json
+++ b/package-lock.json
@@ -268,16 +268,40 @@
       "dev": true
     },
     "assume": {
-      "version": "1.5.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/assume/-/assume-1.5.2.tgz?dl=https://registry.npmjs.org/assume/-/assume-1.5.2.tgz",
-      "integrity": "sha1-BXxaLzPOfRzNjXg9stXQmMrN0RE=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assume/-/assume-2.1.0.tgz",
+      "integrity": "sha512-ugye6y85HyKkMe1GOprT9eGImzGDJ/Yci7/beHE0M63osWljUoiQ7ix6WwxWK5gvEVFnP7b65/ZS7jf1Um17MQ==",
       "dev": true,
       "requires": {
-        "deep-eql": "0.1.x",
-        "fn.name": "1.0.x",
-        "object-inspect": "1.0.x",
-        "pathval": "0.1.x",
-        "pruddy-error": "1.0.x"
+        "deep-eql": "^3.0.1",
+        "fn.name": "^1.0.1",
+        "is-buffer": "^2.0.0",
+        "object-inspect": "^1.5.0",
+        "propget": "^1.1.0",
+        "pruddy-error": "^2.0.2"
+      },
+      "dependencies": {
+        "deep-eql": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+          "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+          "dev": true,
+          "requires": {
+            "type-detect": "^4.0.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+          "dev": true
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+          "dev": true
+        }
       }
     },
     "assume-sinon": {
@@ -2982,9 +3006,9 @@
       }
     },
     "fn.name": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.0.1.tgz",
-      "integrity": "sha1-gBWtFJwQEaEWzbieukzBHZA5rdg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "dev": true
     },
     "for-in": {
@@ -4320,6 +4344,12 @@
         "is-finite": "^1.0.0"
       }
     },
+    "is-node": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-node/-/is-node-1.0.2.tgz",
+      "integrity": "sha1-19ACdF733ru3R36YiVarCk/MtlM=",
+      "dev": true
+    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -4709,6 +4739,12 @@
       "requires": {
         "invert-kv": "^1.0.0"
       }
+    },
+    "left-pad": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "dev": true
     },
     "leven": {
       "version": "1.0.2",
@@ -12640,9 +12676,9 @@
       "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
     },
     "object-inspect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.0.2.tgz",
-      "integrity": "sha1-qXiFtVPldetACevAm92psc0hl5o=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
       "dev": true
     },
     "object.omit": {
@@ -12860,12 +12896,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-    },
-    "pathval": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz",
-      "integrity": "sha1-CPkRzcqczllCiA2ngXvAtyO2bYI=",
-      "dev": true
     },
     "pbkdf2": {
       "version": "3.0.16",
@@ -13216,6 +13246,12 @@
       "integrity": "sha1-46hEBKfs6CDda76p9tkk4xNa4Jw=",
       "dev": true
     },
+    "propget": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/propget/-/propget-1.1.0.tgz",
+      "integrity": "sha1-bBx6yaCcBb21yWfwzY4cCUCf72s=",
+      "dev": true
+    },
     "protobufjs": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-3.8.2.tgz",
@@ -13240,10 +13276,14 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "pruddy-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pruddy-error/-/pruddy-error-1.0.2.tgz",
-      "integrity": "sha1-s37Bo4v5EHwM3FvGY9PU6ANUroA=",
-      "dev": true
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/pruddy-error/-/pruddy-error-2.0.2.tgz",
+      "integrity": "sha512-cEMUxXtU7iD+he5Hh1Jr3RHdTvAID2/VHBpC2TDLWP7UmbvZmR4/B50mQK7lguZhqcBTwdtsN9JI8diVTWedNw==",
+      "dev": true,
+      "requires": {
+        "is-node": "^1.0.2",
+        "left-pad": "^1.2.0"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "winston": "^2.2.0"
   },
   "devDependencies": {
-    "assume": "^1.5.2",
+    "assume": "^2.1.0",
     "assume-sinon": "^1.0.0",
     "babel-eslint": "^6.1.2",
     "eslint": "^4.4.1",

--- a/test/lib/construct/index.test.js
+++ b/test/lib/construct/index.test.js
@@ -477,8 +477,8 @@ describe('Construct', function () {
         assume(getLocalesStub).is.called(1);
         // We end the work as soon as everything is queued, even though we may still end up doing a bit more
         setTimeout(() => {
-          // start, progress, finished, and actual queueing per locale (en-LOL, not-REAL) and progress end
-          assume(writerSpy).is.called(8);
+          // start, progress, finished, and actual queueing per locale (en-LOL, not-REAL) and progress start/end
+          assume(writerSpy).is.called(9);
 
           assertNsqLocaleProgress(writerSpy, 'en-LOL', 'es6');
           assertNsqLocaleProgress(writerSpy, 'not-REAL', 'es6');

--- a/test/lib/construct/status-writer.test.js
+++ b/test/lib/construct/status-writer.test.js
@@ -1,0 +1,316 @@
+/* eslint max-nested-callbacks: 0 */
+const StatusWriter = require('../../../lib/construct/status-writer');
+const assume = require('assume');
+const sinon = require('sinon');
+const nsqStream = require('nsq-stream');
+const { performance } = require('perf_hooks');
+assume.use(require('assume-sinon'));
+
+describe('StatusWriter', function () {
+  let writer;
+  let mockNsqWriter, mockWriteStream;
+  const metadata = {
+    name: 'SomeName',
+    env: 'test',
+    version: '1.2.3-4',
+    type: 'webpack'
+  };
+  const defaultMessage = {
+    eventType: 'event',
+    locale: sinon.match.falsy,
+    details: sinon.match.falsy,
+    name: metadata.name,
+    env: metadata.env,
+    version: metadata.version,
+    buildType: metadata.type
+  };
+  const defaultTopic = 'SomeTopic';
+
+  beforeEach(function () {
+    mockNsqWriter = { publish: sinon.stub() }; // Not an accurate stub, just a placeholder
+
+    mockWriteStream = {
+      write: sinon.stub(),
+      end: sinon.stub(),
+      _writableState: {}
+    };
+
+    sinon.stub(nsqStream, 'createWriteStream').returns(mockWriteStream);
+
+    writer = new StatusWriter({
+      nsq: {
+        writer: mockNsqWriter,
+        topic: defaultTopic
+      },
+      metadata
+    });
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+
+  describe('constructor', function () {
+    it('sets up writer with topic', function () {
+      assume(writer).exists();
+      assume(nsqStream.createWriteStream).calledWith(mockNsqWriter, defaultTopic);
+    });
+
+    it('doesn\'t create stream if no writer', function () {
+      sinon.reset();
+      writer = new StatusWriter({
+        nsq: {
+          topic: defaultTopic
+        },
+        metadata
+      });
+      assume(nsqStream.createWriteStream).was.not.called();
+    });
+
+    it('doesn\'t create stream if no topic', function () {
+      sinon.reset();
+      writer = new StatusWriter({
+        nsq: {
+          writer: mockNsqWriter
+        },
+        metadata
+      });
+      assume(nsqStream.createWriteStream).was.not.called();
+    });
+
+    it('sets up metadata', function () {
+      assume(writer).exists();
+      assume(writer.metadata).to.be.equal(metadata);
+    });
+
+    it('doesn\'t need metadata', function () {
+      writer = new StatusWriter({
+        nsq: {
+          writer: mockNsqWriter,
+          topic: defaultTopic
+        }
+      });
+      assume(writer.metadata).to.deep.equal({});
+    });
+  });
+
+  describe('.write', function () {
+    it('noops without a writeStream', function () {
+      writer.nsqStream = null;
+
+      writer.write(null, 'foo');
+
+      assume(mockWriteStream.write).was.not.called();
+    });
+
+    it('noops without key and data', function () {
+      writer.write(null, null);
+
+      assume(mockWriteStream.write).was.not.called();
+    });
+
+    it('can write simple strings as messages', function () {
+      writer.write(null, 'some string');
+
+      assume(mockWriteStream.write).was.calledWithMatch({
+        ...defaultMessage,
+        message: 'some string'
+      });
+    });
+
+    it('can write objects', function () {
+      writer.write(null, {
+        message: 'much message',
+        locale: 'do-GE',
+        details: 'very detail'
+      });
+
+      assume(mockWriteStream.write).was.calledWithMatch({
+        ...defaultMessage,
+        message: 'much message',
+        locale: 'do-GE',
+        details: 'very detail'
+      });
+    });
+
+    it('writes timing information if given a key', function () {
+      writer.timings.set('theNotTooDistantFuture', performance.now() - 20);
+      writer.write('theNotTooDistantFuture', 'There was a guy named Joel');
+
+      assume(mockWriteStream.write).was.calledWithMatch({
+        ...defaultMessage,
+        message: 'There was a guy named Joel',
+        timing: sinon.match.number
+      });
+    });
+
+    it('writes a complete event when just a key is provided', function () {
+      writer.timings.set('scienceFacts', performance.now() - 20);
+      writer.write('scienceFacts');
+
+      assume(mockWriteStream.write).was.calledWithMatch({
+        ...defaultMessage,
+        message: `'scienceFacts' completed successfully`,
+        timing: sinon.match.number
+      });
+    });
+
+    it('clears timer for the given key', function () {
+      writer.timings.set('eats', performance.now() - 50);
+      writer.timings.set('breathes', performance.now() - 40);
+      writer.timings.set('scienceFacts', performance.now() - 20);
+      writer.write('scienceFacts');
+
+      assume(writer.timings.has('scienceFacts')).is.false();
+      assume(writer.timings.has('eats')).is.true();
+      assume(writer.timings.has('breathes')).is.true();
+    });
+
+    it('can write Errors', function () {
+      writer.write(null, {
+        message: 'How does he eat and breathe?',
+        event: 'error'
+      });
+
+      assume(mockWriteStream.write).was.calledWithMatch({
+        ...defaultMessage,
+        message: 'How does he eat and breathe?',
+        eventType: 'error'
+      });
+    });
+  });
+
+  describe('end', function () {
+    it('noops if no stream', function () {
+      writer.nsqStream = null;
+
+      writer.end('foo');
+
+      assume(mockWriteStream.end).was.not.called();
+    });
+
+    it('writes an end', function () {
+      writer.buildsCompleted = 8675309;
+      writer.end('foo');
+
+      assume(mockWriteStream.end).was.calledWithMatch({
+        ...defaultMessage,
+        eventType: 'foo',
+        total: 8675309,
+        message: 'Builds Queued'
+      });
+    });
+
+    it('can end on an error', function () {
+      writer.buildsCompleted = 8675309;
+      writer.end('error', new Error('Jenny don\'t change your number'));
+
+      assume(mockWriteStream.end).was.calledWithMatch({
+        ...defaultMessage,
+        eventType: 'error',
+        total: 8675309,
+        message: 'Jenny don\'t change your number'
+      });
+    });
+  });
+
+  describe('writeStart', function () {
+    it('writes a status message and starts a timer', function () {
+      assume(writer.timings.has('myKey')).to.be.false();
+      writer.writeStart('myKey', 'some string');
+
+      assume(mockWriteStream.write).was.calledWithMatch({
+        ...defaultMessage,
+        message: 'some string'
+      });
+
+      assume(writer.timings.has('myKey')).to.be.true();
+      assume(writer.timings.get('myKey')).is.a('number');
+    });
+
+    it('writes a default status message', function () {
+      assume(writer.timings.has('myKey')).to.be.false();
+      writer.writeStart('myKey');
+
+      assume(mockWriteStream.write).was.calledWithMatch({
+        ...defaultMessage,
+        message: `'myKey' starting`
+      });
+
+      assume(writer.timings.has('myKey')).to.be.true();
+      assume(writer.timings.get('myKey')).is.a('number');
+    });
+  });
+
+  describe('writeMaybeError', function () {
+    it('writes a default event if no error', function () {
+      writer.timings.set('scienceFacts', performance.now() - 20);
+      writer.writeMaybeError('scienceFacts');
+
+      assume(mockWriteStream.write).was.calledWithMatch({
+        ...defaultMessage,
+        message: `'scienceFacts' completed successfully`,
+        timing: sinon.match.number
+      });
+    });
+
+    it('writes an error event if error passed', function () {
+      writer.timings.set('scienceFacts', performance.now() - 20);
+      const error = new Error('How does he eat and breathe?');
+      writer.writeMaybeError('scienceFacts', error);
+
+      assume(mockWriteStream.write).was.calledWithMatch({
+        ...defaultMessage,
+        eventType: 'error',
+        message: `ERROR: 'scienceFacts' exited with code: Error: How does he eat and breathe?.`,
+        details: sinon.match(details => details && details.message === error.message),
+        timing: sinon.match.number
+      });
+    });
+  });
+
+  describe('writeWrap', function () {
+    it('returns a callback-wrapped function that writes a default event if no error', function (done) {
+      writer.timings.set('scienceFacts', performance.now() - 20);
+      const newCallback = writer.writeWrap('scienceFacts', function (err, data) {
+        assume(err).is.falsey();
+        assume(data).to.equal('la la la');
+
+        assume(mockWriteStream.write).was.calledWithMatch({
+          ...defaultMessage,
+          message: `'scienceFacts' completed successfully`,
+          timing: sinon.match.number
+        });
+
+        done();
+      });
+
+      assume(newCallback).is.a('function');
+      newCallback(null, 'la la la');
+    });
+
+    it('returns a callback-wrapped function that writes an error event if error passed', function (done) {
+      writer.timings.set('scienceFacts', performance.now() - 20);
+      const error = new Error('How does he eat and breathe?');
+      const newCallback = writer.writeWrap('scienceFacts', function (err, data) {
+        assume(err).is.truthy();
+        assume(err.message).to.equal(error.message);
+        assume(data).to.equal('la la la');
+
+        assume(mockWriteStream.write).was.calledWithMatch({
+          ...defaultMessage,
+          eventType: 'error',
+          message: `ERROR: 'scienceFacts' exited with code: Error: How does he eat and breathe?.`,
+          details: sinon.match(details => details && details.message === error.message),
+          timing: sinon.match.number
+        });
+
+        done();
+      });
+
+      assume(newCallback).is.a('function');
+      newCallback(error, 'la la la');
+    });
+  });
+});


### PR DESCRIPTION
Allowing us to more easily track how long various stages are taking.

There is a sister PR for [`carpenterd-worker`](https://github.com/godaddy/carpenterd-worker/pull/7).

I opted for using `performance.now()` over `Date.now()`, for better timing information, but should be easy enough to change if we prefer that.

I also opportunistically fixed a few other issues that were there already:
- failures in `npm install` were being reported as errors even if they were retried and succeeded.  These will now just be normal `event` type, new events were added wrapping the whole set of retries and errors will be reported properly there.
- New status messages for tarball pack/unpack/upload as they happened in a void of status events
- Reworking internals of `status-writer` to more closely match the better pattern in `carpenterd-worker`
- Unit tests for `status-writer`