### PR TITLE
Use async/await

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+- [#41] Extract config
+  - `async/await` conversion
+  - Use `@wrhs/extract-config` to eagerly use the config
+
+- [#40] Modernize files
+  - `prototype` over `class`
+  - Use arrow functions
+
 ### 2.6.0
 
 - Add timing information to status nsq messages

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -511,7 +511,7 @@ class Constructor extends EventEmitter {
     // MAKE ASYNC/AWAIT (await x 4)
     async.series({
       unpack: this.packer.unpack({ content, installPath, statusWriter }),
-      install: this.install.bind(this, spec, installPath, statusWriter),
+      install: this.packer.install({ spec, installPath, statusWriter }),
       pack: this.packer.pack({ pkgDir, tarball, statusWriter }),
       upload: this.packer.upload({ spec, tarball, statusWriter })
     }, (err) => {
@@ -552,38 +552,6 @@ class Constructor extends EventEmitter {
       app.contextLog.info('Uploaded tarball for package', assign({ url }, logOpts));
       next();
     });
-  }
-
-  /**
-   * Install the dependencies of the package with npm.
-   * Uses the provided environment.
-   *
-   * @param {Object} spec Spec
-   * @param {String} installPath os.tmpdir base path to run the install in.
-   * @param {StatusWriter} statusWriter The writer for the status-api
-   * @param {Function} fn Completion callback.
-   * @api public
-   */
-  install(spec, installPath, statusWriter, fn) {
-    const pkgDir = path.join(installPath, 'package');
-
-    const done = fn || function () {};
-    const statusKey = 'npm install-all';
-
-    statusWriter.writeStart(statusKey);
-    const op = retry.op(this.retry);
-    // MAKE ASYNC/AWAIT
-    // https://www.npmjs.com/package/retryme#asyncawait-support
-    op.attempt(next => {
-      npm.install({
-        log: this.app.contextLog,
-        userconfig: this.app.npmrc,
-        installPath,
-        pkgDir,
-        spec,
-        statusWriter
-      }, next);
-    }, statusWriter.writeWrap(statusKey, done));
   }
 
   /**

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -508,17 +508,17 @@ class Constructor extends EventEmitter {
     const { app } = this;
 
     app.contextLog.info('Begin npm install & tarball repack', spec.name, spec);
-    // MAKE ASYNC/AWAIT (await x 4)
-    async.series({
-      unpack: this.packer.unpack({ content, installPath, statusWriter }),
-      install: this.packer.install({ spec, installPath, statusWriter }),
-      pack: this.packer.pack({ pkgDir, tarball, statusWriter }),
-      upload: this.packer.upload({ spec, tarball, statusWriter })
-    }, (err) => {
-      if (err) return next(err);
+    
+    const complete = async function () {
+      await this.packer.unpack({ content, installPath, statusWriter });
+      await this.packer.install({ spec, installPath, statusWriter });
+      await this.packer.pack({ pkgDir, tarball, statusWriter });
+      await this.packer.upload({ spec, tarball, statusWriter });
+    }
 
-      next(null, { install: installPath, tarball });
-    });
+    complete()
+      .then(() => next(null, { install: installPath, tarball }))
+      .catch(next);
   }
 
   /**

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -5,6 +5,7 @@ const EventEmitter = require('events').EventEmitter;
 const intersect = require('lodash.intersection');
 const assign = require('object-assign');
 const Progress = require('./progress');
+const { promisify } = require('util')
 const through = require('through2');
 const uuid = require('node-uuid');
 const crypto = require('crypto');
@@ -119,6 +120,11 @@ class Constructor extends EventEmitter {
       name: data.name
     });
 
+    // will likely need to this.unpack here
+    // which means we need to create paths earlier
+    //
+
+    // MAKE ASYNC/AWAIT
     this.specs(data, (error, spec) => {
       if (error) {
         return void progress.fail(error);
@@ -144,6 +150,7 @@ class Constructor extends EventEmitter {
       spec.source = this.source;
       spec.target = this.target;
 
+      // MAKE ASYNC/AWAIT
       this.prepare(spec, content, statusWriter, (err, paths) => {
         if (err) return done(err);
 
@@ -169,6 +176,7 @@ class Constructor extends EventEmitter {
         };
 
         statusWriter.writeStart(statusKey);
+        // MAKE ASYNC/AWAIT
         return void async.each(spec.locales, (locale, next) => {
           this.buildPerLocale({
             progress,
@@ -227,6 +235,7 @@ class Constructor extends EventEmitter {
    * @param  {Function} next Continuation to respond to when complete.
    * @returns {Stream} progress stream
    */
+  // MAKE ASYNC/AWAIT
   buildOne(spec, next) {
     const { app } = this;
     const progress = new Progress({
@@ -349,6 +358,7 @@ class Constructor extends EventEmitter {
     };
 
     this.emit('queue', topic, freshSpec);
+    // MAKE ASYNC/AWAIT
     return this.nsq.writer.publish(topic, freshSpec, (err) => {
       if (err) {
         app.contextLog.error('Build queue %s for %s env: %s failed %j', current.id, current.name, current.env);
@@ -375,10 +385,12 @@ class Constructor extends EventEmitter {
    *
    * @param {Array} paths Paths that need to be removed
    * @param {function} fn Completion function
+   * @async
    */
   cleanup(paths, fn) {
     const { app } = this;
     paths = Array.isArray(paths) ? paths : [paths];
+    // MAKE ASYNC/AWAIT
     async.each(paths, (path, next) => {
       app.contextLog.info('Cleanup path: %s', path);
       rmrf(path, next);
@@ -399,6 +411,7 @@ class Constructor extends EventEmitter {
     const { app } = this;
     app.contextLog.info('Prepare build for all locales: %s', spec.name, spec);
 
+    // MAKE ASYNC/AWAIT
     this._createPaths(spec, (err, paths) => {
       if (err) return next(err);
 
@@ -442,6 +455,7 @@ class Constructor extends EventEmitter {
     const pkgcloud = this.cdnup.client;
     const filename = `${encodeURIComponent(spec.name)}-${spec.version}.tgz`;
 
+    // MAKE ASYNC/AWAIT
     return void pkgcloud.getFile(this.cdnup.bucket, filename, (err, file) => {
       if (err || !file) {
         app.contextLog.info('%s: tarball %s not found in remote storage', spec.name, filename);
@@ -489,6 +503,7 @@ class Constructor extends EventEmitter {
     const { app } = this;
 
     app.contextLog.info('Begin npm install & tarball repack', spec.name, spec);
+    // MAKE ASYNC/AWAIT (await x 4)
     async.series({
       unpack: this.unpack.bind(this, { content, installPath, statusWriter }),
       install: this.install.bind(this, spec, installPath, statusWriter),
@@ -514,6 +529,7 @@ class Constructor extends EventEmitter {
     const statusKey = 'packing';
     const done = once(statusWriter.writeWrap(statusKey, next));
     statusWriter.writeStart(statusKey);
+    // MAKE ASYNC/AWAIT (wrap as promise)
     tar.pack(source)
       .once('error', done)
       .pipe(zlib.Gzip()) // eslint-disable-line new-cap
@@ -537,6 +553,7 @@ class Constructor extends EventEmitter {
     const done = once(statusWriter.writeWrap(statusKey, next));
     statusWriter.writeStart(statusKey);
 
+    // MAKE ASYNC/AWAIT (wrap as promise)
     stream
       .pipe(zlib.Unzip()) // eslint-disable-line new-cap
       .once('error', done)
@@ -566,6 +583,7 @@ class Constructor extends EventEmitter {
     const filePath = `${encodeURIComponent(spec.name)}-${spec.version}.tgz`;
 
     const logOpts = assign({ tarball }, spec);
+    // MAKE ASYNC/AWAIT (wrap as promise)
     this.cdnup.upload(tarball, filePath, (err, url) => {
       statusWriter.writeMaybeError(statusKey, err);
 
@@ -597,6 +615,8 @@ class Constructor extends EventEmitter {
 
     statusWriter.writeStart(statusKey);
     const op = retry.op(this.retry);
+    // MAKE ASYNC/AWAIT
+    // https://www.npmjs.com/package/retryme#asyncawait-support
     op.attempt(next => {
       npm.install({
         log: this.app.contextLog,
@@ -666,6 +686,7 @@ class Constructor extends EventEmitter {
      * @param {Function} next Completion callback.
      * @api private
      */
+    // MAKE ASYNC/AWAIT
     const getDependencies = (pkg, next) => {
       cache.push(pkg.name);
 
@@ -775,7 +796,7 @@ class Constructor extends EventEmitter {
     //
     // Read the dependency tree and each package.json to determine locales.
     //
-
+    // MAKE ASYNC/AWAIT
     this.getLocales(data, function foundPossibleLocales(error, locales) {
       if (error) {
         return void done(error);
@@ -819,6 +840,7 @@ class Constructor extends EventEmitter {
       }
 
       files = files.filter(this.valid);
+      // MAKE ASYNC/AWAIT
       async.reduce(files, 0, (i, file, next) => {
         file = path.join(target, file);
 
@@ -868,6 +890,7 @@ class Constructor extends EventEmitter {
 
     app.contextLog.info('Create paths for %s spec: %s@%s', spec.env, spec.name, spec.version, paths);
 
+    // MAKE ASYNC/AWAIT Promise.all
     async.parallel([
       async.apply(mkdirp, installRoot),
       async.apply(mkdirp, tarRoot)

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -13,15 +13,10 @@ const async = require('async');
 const errs = require('errs');
 const fitting = require('./fitting');
 const rmrf = require('./rmrf');
-const tar = require('tar-fs');
-const once = require('one-time');
 const path = require('path');
-const npm = require('./npm');
-const zlib = require('zlib');
 const omit = require('lodash.omit');
 const fs = require('fs');
 const os = require('os');
-const retry = require('retryme');
 const emits = require('emits');
 
 //
@@ -508,13 +503,13 @@ class Constructor extends EventEmitter {
     const { app } = this;
 
     app.contextLog.info('Begin npm install & tarball repack', spec.name, spec);
-    
+
     const complete = async function () {
       await this.packer.unpack({ content, installPath, statusWriter });
       await this.packer.install({ spec, installPath, statusWriter });
       await this.packer.pack({ pkgDir, tarball, statusWriter });
       await this.packer.upload({ spec, tarball, statusWriter });
-    }
+    };
 
     complete()
       .then(() => next(null, { install: installPath, tarball }))

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -300,6 +300,7 @@ class Constructor extends EventEmitter {
       id
     }, omit(spec, 'locales'));
 
+    console.log('logging build locale');
     app.contextLog.info('Start build for locale %s', locale, {
       locale: locale,
       name: spec.name,
@@ -341,6 +342,7 @@ class Constructor extends EventEmitter {
     // Launch the build process with the specifications and attach
     // a supervisor to communicate all events back to the developer.
     //
+    console.log('writing to progress');
     progress.write({
       locale,
       progress: true,
@@ -357,14 +359,18 @@ class Constructor extends EventEmitter {
       promote: spec.promote
     };
 
+    console.log('emitting to queue pre nsq build');
     this.emit('queue', topic, freshSpec);
     // MAKE ASYNC/AWAIT
+    console.log('writing to nsq');
     return this.nsq.writer.publish(topic, freshSpec, (err) => {
+      console.log('wrote to nsq');
       if (err) {
         app.contextLog.error('Build queue %s for %s env: %s failed %j', current.id, current.name, current.env);
         return step(err);
       }
 
+      console.log('emitting to queue post nsq');
       this.emit('queued', topic, freshSpec);
       app.contextLog.info('Finished queuing locale %s', locale, {
         locale: locale,
@@ -374,6 +380,7 @@ class Constructor extends EventEmitter {
         id: id
       });
 
+      console.log('finished progress');
       progress.done(id, { locale });
       return void step();
     });

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -509,7 +509,7 @@ class Constructor extends EventEmitter {
       unpack: this.packer.unpack({ content, installPath, statusWriter }),
       install: this.install.bind(this, spec, installPath, statusWriter),
       pack: this.packer.pack({ pkgDir, tarball, statusWriter }),
-      upload: this.upload.bind(this, spec, tarball, statusWriter)
+      upload: this.packer.upload({ spec, tarball, statusWriter })
     }, (err) => {
       if (err) return next(err);
 

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -5,8 +5,7 @@ const EventEmitter = require('events').EventEmitter;
 const intersect = require('lodash.intersection');
 const assign = require('object-assign');
 const Progress = require('./progress');
-const { promisify } = require('util')
-const through = require('through2');
+const Packer = require('./packer');
 const uuid = require('node-uuid');
 const crypto = require('crypto');
 const mkdirp = require('mkdirp');
@@ -90,7 +89,9 @@ class Constructor extends EventEmitter {
       this.purge.bind(this),
       this.timeout
     );
+
     this.emits = emits;
+    this.packer = new Packer();
   }
 
   /**
@@ -505,7 +506,7 @@ class Constructor extends EventEmitter {
     app.contextLog.info('Begin npm install & tarball repack', spec.name, spec);
     // MAKE ASYNC/AWAIT (await x 4)
     async.series({
-      unpack: this.unpack.bind(this, { content, installPath, statusWriter }),
+      unpack: this.packer.unpack.bind(this, { content, installPath, statusWriter }),
       install: this.install.bind(this, spec, installPath, statusWriter),
       pack: this.pack.bind(this, pkgDir, tarball, statusWriter),
       upload: this.upload.bind(this, spec, tarball, statusWriter)
@@ -537,31 +538,6 @@ class Constructor extends EventEmitter {
       .pipe(fs.createWriteStream(target))
       .once('error', done)
       .once('finish', done);
-  }
-
-  /**
-   * Unpack the base64 string content into a proper directory of code
-   *
-   * @param {Object} opts Options for process
-   * @param {Function} next Completion callback.
-   * @api public
-   */
-  unpack(opts, next) {
-    const { content, installPath, statusWriter } = opts;
-    const stream = through();
-    const statusKey = 'unpacking';
-    const done = once(statusWriter.writeWrap(statusKey, next));
-    statusWriter.writeStart(statusKey);
-
-    // MAKE ASYNC/AWAIT (wrap as promise)
-    stream
-      .pipe(zlib.Unzip()) // eslint-disable-line new-cap
-      .once('error', done)
-      .pipe(tar.extract(installPath))
-      .once('error', done)
-      .once('finish', done);
-
-    stream.end(Buffer.from(content, 'base64'));
   }
 
   /**

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -91,7 +91,11 @@ class Constructor extends EventEmitter {
     );
 
     this.emits = emits;
-    this.packer = new Packer();
+    this.packer = new Packer({
+      retry: this.retry,
+      log: app.contextLog,
+      cdnup: this.cdnup
+    });
   }
 
   /**

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -506,38 +506,15 @@ class Constructor extends EventEmitter {
     app.contextLog.info('Begin npm install & tarball repack', spec.name, spec);
     // MAKE ASYNC/AWAIT (await x 4)
     async.series({
-      unpack: done => this.packer.unpack({ content, installPath, statusWriter }, done),
+      unpack: this.packer.unpack({ content, installPath, statusWriter }),
       install: this.install.bind(this, spec, installPath, statusWriter),
-      pack: this.pack.bind(this, pkgDir, tarball, statusWriter),
+      pack: this.packer.pack({ pkgDir, tarball, statusWriter }),
       upload: this.upload.bind(this, spec, tarball, statusWriter)
     }, (err) => {
       if (err) return next(err);
 
       next(null, { install: installPath, tarball });
     });
-  }
-
-  /**
-   * Take the given source directory and create a tarball at the target directory
-   *
-   * @param {String} source Source directory
-   * @param {String} target Target directory
-   * @param {StatusWriter} statusWriter The writer for the status-api
-   * @param {Function} next Completion callback.
-   * @api public
-   */
-  pack(source, target, statusWriter, next) {
-    const statusKey = 'packing';
-    const done = once(statusWriter.writeWrap(statusKey, next));
-    statusWriter.writeStart(statusKey);
-    // MAKE ASYNC/AWAIT (wrap as promise)
-    tar.pack(source)
-      .once('error', done)
-      .pipe(zlib.Gzip()) // eslint-disable-line new-cap
-      .once('error', done)
-      .pipe(fs.createWriteStream(target))
-      .once('error', done)
-      .once('finish', done);
   }
 
   /**

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -426,21 +426,21 @@ class Constructor extends EventEmitter {
       // First see if this package has already been built for a different env, we
       // should only build a single version once
       //
-      this.checkAndDownload(spec, paths, async (err) => {
-        if (err) {
-          if (err.install) {
-            try {
-              await this.packer.repack({ spec, content, paths, statusWriter });
-            } catch (repackErr) {
-              return next(repackErr);
-            }
-          } else {
-            return next(err);
+      try {
+        await this.checkAndDownload(spec, paths);
+      } catch (err) {
+        if (err.install) {
+          try {
+            await this.packer.repack({ spec, content, paths, statusWriter });
+          } catch (repackErr) {
+            return next(repackErr);
           }
+        } else {
+          return next(err);
         }
+      }
 
-        next(null, paths);
-      });
+      next(null, paths);
     });
   }
 
@@ -451,11 +451,10 @@ class Constructor extends EventEmitter {
    * @function checkAndDownload
    * @param {Object} spec - specification for build
    * @param {Object} paths - paths object
-   * @param {Function} next - go to the next step and run builds
-   * @returns {undefined}
+   * @returns {Promise} completion handler
    * @api private
    */
-  checkAndDownload(spec, paths, next) {
+  checkAndDownload(spec, paths) {
     const { app } = this;
     if (!this.cdnup) {
       app.contextLog.info('%s: cdnup not configured. Skip download attempt.', spec.name);
@@ -469,32 +468,34 @@ class Constructor extends EventEmitter {
     const filename = `${encodeURIComponent(spec.name)}-${spec.version}.tgz`;
 
     // MAKE ASYNC/AWAIT
-    return void pkgcloud.getFile(this.cdnup.bucket, filename, (err, file) => {
-      if (err || !file) {
-        app.contextLog.info('%s: tarball %s not found in remote storage', spec.name, filename);
-        return void next(errs.create({
-          message: 'Tarball not found',
-          install: true
-        }));
-      }
+    return new Promise((resolve, reject) => {
+      pkgcloud.getFile(this.cdnup.bucket, filename, (err, file) => {
+        if (err || !file) {
+          app.contextLog.info('%s: tarball %s not found in remote storage', spec.name, filename);
+          return void reject(errs.create({
+            message: 'Tarball not found',
+            install: true
+          }));
+        }
 
-      function onError(err) {
-        app.contextLog.error('Tarball download error for %s: %s', spec.name, err.message);
-        next(err);
-      }
+        function onError(error) {
+          app.contextLog.error('Tarball download error for %s: %s', spec.name, error.message);
+          reject(error);
+        }
 
-      function onFinish() {
-        app.contextLog.info('Tarball download ok for %s: %s', spec.name, paths.tarball);
-        next();
-      }
+        function onFinish() {
+          app.contextLog.info('Tarball download ok for %s: %s', spec.name, paths.tarball);
+          resolve();
+        }
 
-      pkgcloud.download({
-        container: this.cdnup.bucket,
-        remote: filename
-      }).pipe(fs.createWriteStream(paths.tarball))
+        pkgcloud.download({
+          container: this.cdnup.bucket,
+          remote: filename
+        }).pipe(fs.createWriteStream(paths.tarball))
         .once('error', onError)
         .on('finish', onFinish);
-    });
+      });
+    })
   }
 
   /**

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -419,11 +419,17 @@ class Constructor extends EventEmitter {
       // First see if this package has already been built for a different env, we
       // should only build a single version once
       //
-      this.checkAndDownload(spec, paths, (err) => {
+      this.checkAndDownload(spec, paths, async (err) => {
         if (err) {
-          return err.install
-            ? this.repack(spec, content, paths, statusWriter, next)
-            : next(err);
+          if (err.install) {
+            try {
+              await this.packer.repack({ spec, content, paths, statusWriter });
+            } catch (repackErr) {
+              return next(repackErr);
+            }
+          } else {
+            return next(err);
+          }
         }
 
         next(null, paths);
@@ -482,38 +488,6 @@ class Constructor extends EventEmitter {
         .once('error', onError)
         .on('finish', onFinish);
     });
-  }
-
-  /**
-   * Performs a full npm install & repack operation:
-   * 1. Unpack the npm publish payload tarball
-   * 2. Run `npm install` in that directory
-   * 3. Create a new tarball from that directory (this includes node_modules)
-   * 4. Upload that re-packed tarball to S3-compatible CDN
-   *
-   * @param   {Object} spec - specification for build
-   * @param   {String} content – base64 encoded tarball content
-   * @param   {Object} paths - paths object
-   * @param   {StatusWriter} statusWriter - The writer for the status-api
-   * @param   {Function} next - go to the next step and run builds
-   */
-  repack(spec, content, paths, statusWriter, next) {
-    const { tarball, installPath } = paths;
-    const pkgDir = path.join(installPath, 'package');
-    const { app } = this;
-
-    app.contextLog.info('Begin npm install & tarball repack', spec.name, spec);
-
-    const complete = async function () {
-      await this.packer.unpack({ content, installPath, statusWriter });
-      await this.packer.install({ spec, installPath, statusWriter });
-      await this.packer.pack({ pkgDir, tarball, statusWriter });
-      await this.packer.upload({ spec, tarball, statusWriter });
-    };
-
-    complete()
-      .then(() => next(null, { install: installPath, tarball }))
-      .catch(next);
   }
 
   /**

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -506,7 +506,7 @@ class Constructor extends EventEmitter {
     app.contextLog.info('Begin npm install & tarball repack', spec.name, spec);
     // MAKE ASYNC/AWAIT (await x 4)
     async.series({
-      unpack: this.packer.unpack({ content, installPath, statusWriter }),
+      unpack: done => this.packer.unpack({ content, installPath, statusWriter }, done),
       install: this.install.bind(this, spec, installPath, statusWriter),
       pack: this.pack.bind(this, pkgDir, tarball, statusWriter),
       upload: this.upload.bind(this, spec, tarball, statusWriter)

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -517,39 +517,6 @@ class Constructor extends EventEmitter {
   }
 
   /**
-   * Upload the given file to our configured endpoint
-   *
-   * @param {Object} spec Defines this package
-   * @param {String} tarball Path to tarball
-   * @param {StatusWriter} statusWriter The writer for the status-api
-   * @param {Function} next Optional completion callback.
-   *
-   * @returns {undefined} Nothing special
-   * @api public
-   */
-  upload(spec, tarball, statusWriter, next) {
-    if (!this.cdnup) return setImmediate(next);
-    const { app } = this;
-    const statusKey = 'uploading';
-    statusWriter.writeStart(statusKey);
-    const filePath = `${encodeURIComponent(spec.name)}-${spec.version}.tgz`;
-
-    const logOpts = assign({ tarball }, spec);
-    // MAKE ASYNC/AWAIT (wrap as promise)
-    this.cdnup.upload(tarball, filePath, (err, url) => {
-      statusWriter.writeMaybeError(statusKey, err);
-
-      if (err) {
-        return app.contextLog.error('Failed to upload tarball for package',
-          assign({ error: err.message }, logOpts));
-      }
-
-      app.contextLog.info('Uploaded tarball for package', assign({ url }, logOpts));
-      next();
-    });
-  }
-
-  /**
    * Extract package content from the JSON body.
    *
    * @param {Object} data Package data.

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -506,7 +506,7 @@ class Constructor extends EventEmitter {
     app.contextLog.info('Begin npm install & tarball repack', spec.name, spec);
     // MAKE ASYNC/AWAIT (await x 4)
     async.series({
-      unpack: this.packer.unpack.bind(this, { content, installPath, statusWriter }),
+      unpack: this.packer.unpack({ content, installPath, statusWriter }),
       install: this.install.bind(this, spec, installPath, statusWriter),
       pack: this.pack.bind(this, pkgDir, tarball, statusWriter),
       upload: this.upload.bind(this, spec, tarball, statusWriter)

--- a/lib/construct/index.js
+++ b/lib/construct/index.js
@@ -9,6 +9,8 @@ const Packer = require('./packer');
 const uuid = require('node-uuid');
 const crypto = require('crypto');
 const mkdirp = require('mkdirp');
+const { promisify } = require('util');
+const mkdirpAsync = promisify(mkdirp);
 const async = require('async');
 const errs = require('errs');
 const fitting = require('./fitting');
@@ -414,34 +416,37 @@ class Constructor extends EventEmitter {
    * @param {Function} next Completion callback.
    * @api public
    */
-  prepare(spec, content, statusWriter, next) {
+  async prepare(spec, content, statusWriter, next) {
     const { app } = this;
     app.contextLog.info('Prepare build for all locales: %s', spec.name, spec);
 
     // MAKE ASYNC/AWAIT
-    this._createPaths(spec, (err, paths) => {
-      if (err) return next(err);
+    let paths;
+    try {
+      paths = this._createPaths(spec);
+    } catch (err) {
+      return void next(err);
+    }
 
-      //
-      // First see if this package has already been built for a different env, we
-      // should only build a single version once
-      //
-      try {
-        await this.checkAndDownload(spec, paths);
-      } catch (err) {
-        if (err.install) {
-          try {
-            await this.packer.repack({ spec, content, paths, statusWriter });
-          } catch (repackErr) {
-            return next(repackErr);
-          }
-        } else {
-          return next(err);
+    //
+    // First see if this package has already been built for a different env, we
+    // should only build a single version once
+    //
+    try {
+      await this.checkAndDownload(spec, paths);
+    } catch (err) {
+      if (err.install) {
+        try {
+          await this.packer.repack({ spec, content, paths, statusWriter });
+        } catch (repackErr) {
+          return next(repackErr);
         }
+      } else {
+        return next(err);
       }
+    }
 
-      next(null, paths);
-    });
+    next(null, paths);
   }
 
   /**
@@ -458,7 +463,7 @@ class Constructor extends EventEmitter {
     const { app } = this;
     if (!this.cdnup) {
       app.contextLog.info('%s: cdnup not configured. Skip download attempt.', spec.name);
-      return void next(errs.create({
+      throw new Error(errs.create({
         message: 'cdnup is not configured',
         install: true
       }));
@@ -492,10 +497,10 @@ class Constructor extends EventEmitter {
           container: this.cdnup.bucket,
           remote: filename
         }).pipe(fs.createWriteStream(paths.tarball))
-        .once('error', onError)
-        .on('finish', onFinish);
+          .once('error', onError)
+          .on('finish', onFinish);
       });
-    })
+    });
   }
 
   /**
@@ -748,9 +753,9 @@ class Constructor extends EventEmitter {
    * Create the given paths for a tarball download or npm install
    *
    * @param {Object} spec Build specification
-   * @param {function} next Completion function
+   * @returns {Promise} Completion handler for generated paths
    */
-  _createPaths(spec, next) {
+  async _createPaths(spec) {
     const { app, installRoot, tarRoot } = this;
     const uniq = `${encodeURIComponent(spec.name)}-${spec.version}-${spec.env}-${crypto.randomBytes(5).toString('hex')}`;
     const installPath = path.join(installRoot, uniq);
@@ -759,11 +764,10 @@ class Constructor extends EventEmitter {
 
     app.contextLog.info('Create paths for %s spec: %s@%s', spec.env, spec.name, spec.version, paths);
 
-    // MAKE ASYNC/AWAIT Promise.all
-    async.parallel([
-      async.apply(mkdirp, installRoot),
-      async.apply(mkdirp, tarRoot)
-    ], (err) => next(err, paths));
+    return await Promise.all([
+      mkdirpAsync(installRoot),
+      mkdirpAsync(tarRoot)
+    ]);
   }
 }
 

--- a/lib/construct/npm/index.js
+++ b/lib/construct/npm/index.js
@@ -9,6 +9,7 @@ const npm = path.join(require.resolve('npm'), '..', '..', 'bin', 'npm-cli.js');
 const assign = Object.assign;
 const statusKey = 'npm install';
 
+// MAKE ASYNC/AWAIT
 exports.install = function (opts, callback) {
   const { log, spec, installPath, pkgDir, userconfig, statusWriter } = opts;
   const done = once(callback);

--- a/lib/construct/npm/index.js
+++ b/lib/construct/npm/index.js
@@ -10,7 +10,7 @@ const assign = Object.assign;
 const statusKey = 'npm install';
 
 // MAKE ASYNC/AWAIT
-exports.install = function (opts, callback) {
+function install (opts, callback) {
   const { log, spec, installPath, pkgDir, userconfig, statusWriter } = opts;
   const done = once(callback);
   const env = assign({}, process.env);
@@ -68,5 +68,15 @@ exports.install = function (opts, callback) {
     statusWriter.write(statusKey, `'npm install' attempt completed successfully`);
     return done();
   });
-
 };
+
+function installAsync (opts) {
+  return new Promise((resolve, reject) => {
+    install(opts, e => e ? reject(err) : resolve()
+  });
+}
+
+exports = {
+  install,
+  installAsync
+}

--- a/lib/construct/npm/index.js
+++ b/lib/construct/npm/index.js
@@ -10,7 +10,7 @@ const assign = Object.assign;
 const statusKey = 'npm install';
 
 // MAKE ASYNC/AWAIT
-function install (opts, callback) {
+function install(opts, callback) {
   const { log, spec, installPath, pkgDir, userconfig, statusWriter } = opts;
   const done = once(callback);
   const env = assign({}, process.env);
@@ -68,15 +68,15 @@ function install (opts, callback) {
     statusWriter.write(statusKey, `'npm install' attempt completed successfully`);
     return done();
   });
-};
+}
 
-function installAsync (opts) {
+function installAsync(opts) {
   return new Promise((resolve, reject) => {
-    install(opts, e => e ? reject(err) : resolve()
+    install(opts, e => e ? reject(e) : resolve());
   });
 }
 
-exports = {
+module.exports = {
   install,
   installAsync
-}
+};

--- a/lib/construct/packer.js
+++ b/lib/construct/packer.js
@@ -156,10 +156,10 @@ class Packer {
     const pkgDir = path.join(installPath, 'package');
     this.log.info('Begin npm install & tarball repack', spec.name, spec);
 
-    await this.packer.unpack({ content, installPath, statusWriter });
-    await this.packer.install({ spec, installPath, statusWriter });
-    await this.packer.pack({ pkgDir, tarball, statusWriter });
-    await this.packer.upload({ spec, tarball, statusWriter });
+    await this.unpack({ content, installPath, statusWriter });
+    await this.install({ spec, installPath, statusWriter });
+    await this.pack({ pkgDir, tarball, statusWriter });
+    await this.upload({ spec, tarball, statusWriter });
 
     return { install: installPath, tarball };
   }

--- a/lib/construct/packer.js
+++ b/lib/construct/packer.js
@@ -1,6 +1,9 @@
 const through = require('through2');
 const once = require('one-time');
+const retry = require('retryme');
 const zlib = require('zlib');
+const path = require('path');
+const npm = require('./npm');
 const tar = require('tar');
 
 class Packer {
@@ -46,8 +49,47 @@ class Packer {
     }
   }
 
-  install() {
+  /**
+   * Install the dependencies of the package with npm.
+   * Uses the provided environment.
+   *
+   * @param {Object} options
+   * @param {Object} options.spec Spec
+   * @param {String} options.installPath os.tmpdir base path to run the install in.
+   * @param {StatusWriter} options.statusWriter The writer for the status-api
+   *
+   * @returns {Promise} completion handler
+   */
+   async _install({ spec, installPath, statusWriter }) {
+     const pkgDir = path.join(installPath, 'package');
+     const statusKey = 'npm install-all';
 
+     statusWriter.writeStart(statusKey);
+     const op = retry.op(this.retry);
+     // MAKE ASYNC/AWAIT
+     // https://www.npmjs.com/package/retryme#asyncawait-support
+     await op.async(() => npm.installAsync({
+       log: this.app.contextLog,
+       userconfig: this.app.npmrc,
+       installPath,
+       pkgDir,
+       spec,
+       statusWriter
+     }));
+
+     return new Promise((resolve, reject) => {
+       statusWriter.writeWrap(statusKey, (err, data) => {
+         err ? reject(err) : resolve(data);
+       });
+     });
+   }
+
+  install(options) {
+    return next => {
+      this._install(options)
+        .then(next)
+        .catch(next);
+    }
   }
 
   /**

--- a/lib/construct/packer.js
+++ b/lib/construct/packer.js
@@ -10,7 +10,7 @@ class Packer {
    * @param  {Object} options options for the process
    * @param  {String} options.content TBD
    * @param  {String} options.installPath TBD
-   * @param  {Object} options.statusWriter TBD
+   * @param  {StatusWriter} options.statusWriter The writer for the status-api
    * @returns {Promise} completion handler
    */
   _unpack(options) {
@@ -23,7 +23,6 @@ class Packer {
       const succeed = once(statusWriter.writeWrap(statusKey, resolve));
       const fail = once(statusWriter.writeWrap(statusKey, reject));
 
-      // MAKE ASYNC/AWAIT (wrap as promise)
       stream
         .pipe(zlib.Unzip()) // eslint-disable-line new-cap
         .once('error', fail)
@@ -36,17 +35,49 @@ class Packer {
   }
 
   unpack(options, next) {
-    this._unpack(options)
-      .then(next)
-      .catch(next);
+    return next => {
+      this._unpack(options)
+        .then(next)
+        .catch(next);
+    }
   }
 
-  bind() {
-
+  install() {
+    
   }
 
-  pack() {
+  /**
+   * Take the given source directory and create a tarball at the target directory
+   *
+   * @param {Object} options configuration
+   * @param {String} options.source Source directory
+   * @param {String} options.target Target directory
+   * @param {StatusWriter} options.statusWriter The writer for the status-api
+   * @returns {Promise} completion handler
+   */
+  _pack({source, target, statusWriter}) {
+    const statusKey = 'packing';
+    statusWriter.writeStart(statusKey);
 
+    return new Promise((resolve, reject) => {
+      const succeed = once(statusWriter.writeWrap(statusKey, resolve));
+      const fail = once(statusWriter.writeWrap(statusKey, reject));
+      tar.pack(source)
+        .once('error', fail)
+        .pipe(zlib.Gzip()) // eslint-disable-line new-cap
+        .once('error', fail)
+        .pipe(fs.createWriteStream(target))
+        .once('error', fail)
+        .once('finish', succeed);
+    });
+  }
+
+  pack(options, next) {
+    return next => {
+      this._pack(options)
+        .then(next)
+        .catch(next);
+    }
   }
 
   upload() {

--- a/lib/construct/packer.js
+++ b/lib/construct/packer.js
@@ -13,8 +13,7 @@ class Packer {
    * @param  {StatusWriter} options.statusWriter The writer for the status-api
    * @returns {Promise} completion handler
    */
-  _unpack(options) {
-    const { content, installPath, statusWriter } = options;
+  _unpack({ content, installPath, statusWriter }) {
     const stream = through();
     const statusKey = 'unpacking';
     statusWriter.writeStart(statusKey);
@@ -43,7 +42,7 @@ class Packer {
   }
 
   install() {
-    
+
   }
 
   /**
@@ -55,7 +54,7 @@ class Packer {
    * @param {StatusWriter} options.statusWriter The writer for the status-api
    * @returns {Promise} completion handler
    */
-  _pack({source, target, statusWriter}) {
+  _pack({ source, target, statusWriter }) {
     const statusKey = 'packing';
     statusWriter.writeStart(statusKey);
 
@@ -80,10 +79,51 @@ class Packer {
     }
   }
 
-  upload() {
+  /**
+   * Upload the given file to our configured endpoint
+   *
+   * @param {Object} options configuration
+   * @param {Object} options.spec Defines this package
+   * @param {String} options.tarball Path to tarball
+   * @param {StatusWriter} options.statusWriter The writer for the status-api
+   *
+   * @returns {Promise} completion handler
+   */
+  _upload({ spec, tarball, statusWriter }) {
+    if (!this.cdnup) return;
+    // const { app } = this;
+    const statusKey = 'uploading';
+    statusWriter.writeStart(statusKey);
+    const filePath = `${encodeURIComponent(spec.name)}-${spec.version}.tgz`;
 
+    const logOpts = { tarball, ...spec };
+    // TODO: app.context log instead of console
+    return new Promise((resolve) => {
+      this.cdnup.upload(tarball, filePath, (err, url) => {
+        statusWriter.writeMaybeError(statusKey, err);
+
+        if (err) {
+          return console.error(
+            'Failed to upload tarball for package',
+            { { error: err.message }, ...logOpts }
+          );
+        }
+
+        console.info('Uploaded tarball for package', assign(
+          { { url }, ...logOpts }
+        );
+        resolve();
+      });
+    })
   }
 
+  upload(options, next) {
+    return next => {
+      this._upload(options)
+        .then(next)
+        .catch(next);
+    }
+  }
 }
 
 module.exports = Packer;

--- a/lib/construct/packer.js
+++ b/lib/construct/packer.js
@@ -4,6 +4,11 @@ const zlib = require('zlib');
 const tar = require('tar');
 
 class Packer {
+  constructor(options) {
+    this.retry = options.retry;
+    this.log = options.log;
+    this.cdnup = options.cdnup;
+  }
 
   /**
    * Unpack the base64 string content into a proper directory of code
@@ -91,25 +96,23 @@ class Packer {
    */
   _upload({ spec, tarball, statusWriter }) {
     if (!this.cdnup) return;
-    // const { app } = this;
     const statusKey = 'uploading';
     statusWriter.writeStart(statusKey);
     const filePath = `${encodeURIComponent(spec.name)}-${spec.version}.tgz`;
 
     const logOpts = { tarball, ...spec };
-    // TODO: app.context log instead of console
     return new Promise((resolve) => {
       this.cdnup.upload(tarball, filePath, (err, url) => {
         statusWriter.writeMaybeError(statusKey, err);
 
         if (err) {
-          return console.error(
+          return this.log.error(
             'Failed to upload tarball for package',
             { { error: err.message }, ...logOpts }
           );
         }
 
-        console.info('Uploaded tarball for package', assign(
+        this.log.info('Uploaded tarball for package', assign(
           { { url }, ...logOpts }
         );
         resolve();

--- a/lib/construct/packer.js
+++ b/lib/construct/packer.js
@@ -71,8 +71,8 @@ class Packer {
     }));
 
     return new Promise((resolve, reject) => {
-      statusWriter.writeWrap(statusKey, (err, data) => {
-        err ? reject(err) : resolve(data);
+      statusWriter.writeWrap(statusKey, (err) => {
+        err ? reject(err) : resolve();
       });
     });
   }
@@ -135,6 +135,33 @@ class Packer {
         resolve();
       });
     });
+  }
+
+  /**
+   * Performs a full npm install & repack operation:
+   * 1. Unpack the npm publish payload tarball
+   * 2. Run `npm install` in that directory
+   * 3. Create a new tarball from that directory (this includes node_modules)
+   * 4. Upload that re-packed tarball to S3-compatible CDN
+   *
+   * @param   {Object} options configuration
+   * @param   {Object} options.spec - specification for build
+   * @param   {String} options.content – base64 encoded tarball content
+   * @param   {Object} options.paths - paths object
+   * @param   {StatusWriter} statusWriter - The writer for the status-api
+   * @returns  {Promise} completion handler
+   */
+  async repack({ spec, content, paths, statusWriter }) {
+    const { tarball, installPath } = paths;
+    const pkgDir = path.join(installPath, 'package');
+    this.log.info('Begin npm install & tarball repack', spec.name, spec);
+
+    await this.packer.unpack({ content, installPath, statusWriter });
+    await this.packer.install({ spec, installPath, statusWriter });
+    await this.packer.pack({ pkgDir, tarball, statusWriter });
+    await this.packer.upload({ spec, tarball, statusWriter });
+
+    return { install: installPath, tarball };
   }
 }
 

--- a/lib/construct/packer.js
+++ b/lib/construct/packer.js
@@ -1,0 +1,58 @@
+const through = require('through2');
+const once = require('one-time');
+const zlib = require('zlib');
+const tar = require('tar');
+
+class Packer {
+
+  /**
+   * Unpack the base64 string content into a proper directory of code
+   * @param  {Object} options options for the process
+   * @param  {String} options.content TBD
+   * @param  {String} options.installPath TBD
+   * @param  {Object} options.statusWriter TBD
+   * @returns {Promise} completion handler
+   */
+  _unpack(options) {
+    const { content, installPath, statusWriter } = options;
+    const stream = through();
+    const statusKey = 'unpacking';
+    statusWriter.writeStart(statusKey);
+
+    return new Promise((resolve, reject) => {
+      const succeed = once(statusWriter.writeWrap(statusKey, resolve));
+      const fail = once(statusWriter.writeWrap(statusKey, reject));
+
+      // MAKE ASYNC/AWAIT (wrap as promise)
+      stream
+        .pipe(zlib.Unzip()) // eslint-disable-line new-cap
+        .once('error', fail)
+        .pipe(tar.extract(installPath))
+        .once('error', fail)
+        .once('finish', succeed);
+
+      stream.end(Buffer.from(content, 'base64'));
+    });
+  }
+
+  unpack(options, next) {
+    this._unpack(options)
+      .then(next)
+      .catch(next);
+  }
+
+  bind() {
+
+  }
+
+  pack() {
+
+  }
+
+  upload() {
+
+  }
+
+}
+
+module.exports = Packer;

--- a/lib/construct/packer.js
+++ b/lib/construct/packer.js
@@ -5,6 +5,7 @@ const zlib = require('zlib');
 const path = require('path');
 const npm = require('./npm');
 const tar = require('tar');
+const fs = require('fs');
 
 class Packer {
   constructor(options) {
@@ -45,36 +46,36 @@ class Packer {
    * Install the dependencies of the package with npm.
    * Uses the provided environment.
    *
-   * @param {Object} options
+   * @param {Object} options configuration
    * @param {Object} options.spec Spec
    * @param {String} options.installPath os.tmpdir base path to run the install in.
    * @param {StatusWriter} options.statusWriter The writer for the status-api
    *
    * @returns {Promise} completion handler
    */
-   async install({ spec, installPath, statusWriter }) {
-     const pkgDir = path.join(installPath, 'package');
-     const statusKey = 'npm install-all';
+  async install({ spec, installPath, statusWriter }) {
+    const pkgDir = path.join(installPath, 'package');
+    const statusKey = 'npm install-all';
 
-     statusWriter.writeStart(statusKey);
-     const op = retry.op(this.retry);
-     // MAKE ASYNC/AWAIT
-     // https://www.npmjs.com/package/retryme#asyncawait-support
-     await op.async(() => npm.installAsync({
-       log: this.app.contextLog,
-       userconfig: this.app.npmrc,
-       installPath,
-       pkgDir,
-       spec,
-       statusWriter
-     }));
+    statusWriter.writeStart(statusKey);
+    const op = retry.op(this.retry);
+    // MAKE ASYNC/AWAIT
+    // https://www.npmjs.com/package/retryme#asyncawait-support
+    await op.async(() => npm.installAsync({
+      log: this.app.contextLog,
+      userconfig: this.app.npmrc,
+      installPath,
+      pkgDir,
+      spec,
+      statusWriter
+    }));
 
-     return new Promise((resolve, reject) => {
-       statusWriter.writeWrap(statusKey, (err, data) => {
-         err ? reject(err) : resolve(data);
-       });
-     });
-   }
+    return new Promise((resolve, reject) => {
+      statusWriter.writeWrap(statusKey, (err, data) => {
+        err ? reject(err) : resolve(data);
+      });
+    });
+  }
 
   /**
    * Take the given source directory and create a tarball at the target directory
@@ -126,16 +127,14 @@ class Packer {
         if (err) {
           return this.log.error(
             'Failed to upload tarball for package',
-            { { error: err.message }, ...logOpts }
+            { error: err.message, ...logOpts }
           );
         }
 
-        this.log.info('Uploaded tarball for package', assign(
-          { { url }, ...logOpts }
-        );
+        this.log.info('Uploaded tarball for package', { url, ...logOpts });
         resolve();
       });
-    })
+    });
   }
 }
 

--- a/lib/construct/packer.js
+++ b/lib/construct/packer.js
@@ -21,7 +21,7 @@ class Packer {
    * @param  {StatusWriter} options.statusWriter The writer for the status-api
    * @returns {Promise} completion handler
    */
-  _unpack({ content, installPath, statusWriter }) {
+  unpack({ content, installPath, statusWriter }) {
     const stream = through();
     const statusKey = 'unpacking';
     statusWriter.writeStart(statusKey);
@@ -41,14 +41,6 @@ class Packer {
     });
   }
 
-  unpack(options, next) {
-    return next => {
-      this._unpack(options)
-        .then(next)
-        .catch(next);
-    }
-  }
-
   /**
    * Install the dependencies of the package with npm.
    * Uses the provided environment.
@@ -60,7 +52,7 @@ class Packer {
    *
    * @returns {Promise} completion handler
    */
-   async _install({ spec, installPath, statusWriter }) {
+   async install({ spec, installPath, statusWriter }) {
      const pkgDir = path.join(installPath, 'package');
      const statusKey = 'npm install-all';
 
@@ -84,14 +76,6 @@ class Packer {
      });
    }
 
-  install(options) {
-    return next => {
-      this._install(options)
-        .then(next)
-        .catch(next);
-    }
-  }
-
   /**
    * Take the given source directory and create a tarball at the target directory
    *
@@ -101,7 +85,7 @@ class Packer {
    * @param {StatusWriter} options.statusWriter The writer for the status-api
    * @returns {Promise} completion handler
    */
-  _pack({ source, target, statusWriter }) {
+  pack({ source, target, statusWriter }) {
     const statusKey = 'packing';
     statusWriter.writeStart(statusKey);
 
@@ -118,14 +102,6 @@ class Packer {
     });
   }
 
-  pack(options, next) {
-    return next => {
-      this._pack(options)
-        .then(next)
-        .catch(next);
-    }
-  }
-
   /**
    * Upload the given file to our configured endpoint
    *
@@ -136,7 +112,7 @@ class Packer {
    *
    * @returns {Promise} completion handler
    */
-  _upload({ spec, tarball, statusWriter }) {
+  upload({ spec, tarball, statusWriter }) {
     if (!this.cdnup) return;
     const statusKey = 'uploading';
     statusWriter.writeStart(statusKey);
@@ -160,14 +136,6 @@ class Packer {
         resolve();
       });
     })
-  }
-
-  upload(options, next) {
-    return next => {
-      this._upload(options)
-        .then(next)
-        .catch(next);
-    }
   }
 }
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -48,6 +48,7 @@ module.exports = function routes(app, options, done) {
         }));
       }
 
+      // MAKE ASYNC/AWAIT
       app.scheduler.schedule(env, (err, counts) => {
         if (err) return app.terminate(res, err);
 
@@ -61,6 +62,7 @@ module.exports = function routes(app, options, done) {
       joi.validate(req.body || {}, buildOneSchema, (err, data) => {
         if (err) return app.terminate(res, err);
 
+        // MAKE ASYNC/AWAIT
         app.construct.buildOne(data, (err) => {
           if (err) {
             return void app.contextLog.error('Failed to build', err);
@@ -76,6 +78,7 @@ module.exports = function routes(app, options, done) {
       // A specific indicator so that we know it was a publish that didn't come from feedsme
       if (!data.env) data.__published = true;
 
+      // MAKE ASYNC/AWAIT
       app.feedsme.change(data.env || 'dev', { data: { data, promote } }, function posted(error) {
         return error
           ? app.contextLog.error('Failed to process changes', error)
@@ -98,6 +101,7 @@ module.exports = function routes(app, options, done) {
           return void app.terminate(res, error);
         }
 
+        // MAKE ASYNC/AWAIT
         return app.construct.build(buildOpts, function building(err) {
           if (err) {
             return void app.contextLog.error('Failed to build', err);
@@ -125,6 +129,7 @@ module.exports = function routes(app, options, done) {
           return void app.terminate(res, error);
         }
 
+        // MAKE ASYNC/AWAIT
         return app.construct.build({ data, promote }, function building(err) {
           if (err) {
             return void app.contextLog.error('Failed to build', err);

--- a/test/lib/routes/index.test.js
+++ b/test/lib/routes/index.test.js
@@ -102,6 +102,7 @@ describe('Application routes', function () {
   }
 
   function validateMessages(data) {
+    console.log(data)
     data = JSON.parse(data);
 
     assume(data.task).to.not.equal('ignored');
@@ -114,7 +115,7 @@ describe('Application routes', function () {
   }
 
   describe('/v2/build', function () {
-    it('accepts npm publish JSON payloads and returns finished task messages', function (done) {
+    it.only('accepts npm publish JSON payloads and returns finished task messages', function (done) {
       nockFeedme();
 
       fs.createReadStream(v2payload)

--- a/test/lib/routes/index.test.js
+++ b/test/lib/routes/index.test.js
@@ -102,7 +102,7 @@ describe('Application routes', function () {
   }
 
   function validateMessages(data) {
-    console.log(data)
+    console.log(data);
     data = JSON.parse(data);
 
     assume(data.task).to.not.equal('ignored');


### PR DESCRIPTION
In preparation for consuming `@wrhs/extract-config` and `workers-factory@1.7.4`

- [ ] `async/await` conversion of `lib/construct/index.js`
- [ ] Make sure the tests still pass so ensure functional parity.