### PR TITLE
[fix] add retries around nsq publish for some more robustness

### DIFF
--- a/lib/construct/builder.js
+++ b/lib/construct/builder.js
@@ -1,6 +1,8 @@
 const uuid = require('node-uuid');
 const assign = require('object-assign');
 const omit = require('lodash.omit');
+const retry = require('retryme');
+const limiter = require('p-limit');
 
 class Builder {
   constructor(context) {
@@ -81,12 +83,14 @@ class Builder {
 
     statusWriter.writeStart(statusKey);
 
-    const tasks = spec.locales.map(async locale => {
-      await this.buildPerLocale({
+    const limit = limiter(this.context.throttle);
+
+    const tasks = spec.locales.map(locale => {
+      return limit(() => this.buildPerLocale({
         progress,
         locale,
         spec
-      });
+      }));
     });
 
     try {
@@ -174,12 +178,19 @@ class Builder {
 
     this.context.emit('queue', topic, freshSpec);
     return new Promise((resolve, reject) => {
-      this.context.nsq.writer.publish(topic, freshSpec, (err) => {
+      const op = retry.op();
+      op.attempt(next => {
+        this.context.nsq.writer.publish(topic, freshSpec, (err) => {
+          if (err) {
+            app.contextLog.warn('Error writing job to nsq, retries remaining %d', op.retries);
+          }
+          next(err);
+        });
+      }, err => {
         if (err) {
           app.contextLog.error('Build queue %s for %s env: %s failed %j', current.id, current.name, current.env);
-          const key = this.context._key(spec);
           progress.fail(err, id, { locale });
-          app.contextLog.error('Error in step %s for %s: %s', err.stack, spec.name, err.message, {
+          app.contextLog.error('Error in writing job to nsq %s for %s: %s', err.stack, spec.name, err.message, {
             locale,
             name: spec.name,
             version: spec.version,
@@ -187,12 +198,7 @@ class Builder {
             promote: spec.promote,
             id
           });
-
-          this.context.failures[key] = this.context.failures[key] || 0;
-          if (++this.context.failures[key] >= this.context.maxFailures) {
-            return reject(err);
-          }
-          return resolve();
+          return reject(err);
         }
 
         this.context.emit('queued', topic, freshSpec);

--- a/lib/construct/builder.js
+++ b/lib/construct/builder.js
@@ -180,7 +180,7 @@ class Builder {
     return new Promise((resolve, reject) => {
       const op = retry.op();
       op.attempt(next => {
-        this.context.nsq.writer.publish(topic, freshSpec, (err) => {
+        this.context.nsq.writer.publish(topic, freshSpec, err => {
           if (err) {
             app.contextLog.warn('Error writing job to nsq, retries remaining %d', op.retries);
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7265,7 +7265,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -7281,7 +7281,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
@@ -7310,7 +7310,7 @@
         },
         "uuid": {
           "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "resolved": false,
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
           "dev": true
         },
@@ -7327,7 +7327,7 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
@@ -7515,10 +7515,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-      "dev": true,
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -7535,8 +7534,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "package-hash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "nsq.js-k8": "^1.1.3",
     "object-assign": "~4.1.1",
     "one-time": "~1.0.0",
+    "p-limit": "^2.2.1",
     "repair": "~0.1.0",
     "resolve": "~1.11.1",
     "retryme": "^1.1.0",

--- a/test/lib/construct/index.test.js
+++ b/test/lib/construct/index.test.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const Writer = require('../../mocks').Writer;
+const MockProgress = require('../../mocks').Progress;
 const sinon = require('sinon');
 
 describe('Construct', function () {
@@ -425,6 +426,44 @@ describe('Construct', function () {
       });
 
       assume(progress).to.be.instanceof(Progress);
+    });
+  });
+
+  describe('#construct.builder', function () {
+
+    it('should publish to nsq only once for a single locale if there is no error on publish', async function () {
+      const spec = {
+        name: 'my-package',
+        version: '7.0.0',
+        env: 'dev',
+        promote: true,
+        type: 'webpack'
+      };
+      const progress = new MockProgress();
+      const locale = 'en-US';
+      const writerStub = sinon.stub(construct.nsq.writer, 'publish')
+      writerStub.yieldsAsync(null, 'woooo');
+
+      await construct.builder.buildPerLocale({ spec, progress, locale });
+      assume(writerStub).is.called(1);
+    });
+
+    it('should retry on buildPerLocale on initial nsq failure', async function () {
+      const spec = {
+        name: 'my-package',
+        version: '7.0.0',
+        env: 'dev',
+        promote: true,
+        type: 'webpack'
+      };
+      const progress = new MockProgress();
+      const locale = 'en-US';
+      const writerStub = sinon.stub(construct.nsq.writer, 'publish');
+      writerStub.onCall(0).yieldsAsync(new Error('Whoops'));
+      writerStub.onCall(1).yieldsAsync(null, 'woooo');
+
+      await construct.builder.buildPerLocale({ spec, progress, locale });
+      assume(writerStub).is.called(2);
     });
   });
 });

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -5,3 +5,13 @@ function Writer() {}
 Writer.prototype.publish = function (topic, payload, fn) {
   setImmediate(fn);
 };
+
+class Progress {
+  start() {}
+  fail() {}
+  write() {}
+  done() {}
+}
+
+exports.Progress = Progress
+


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
Add retries around publish to mitigate network uncertainty. While we do have the catchup route that gets used if a job is dropped somehow, that should be targeted at jobs somehow dropped after succeeding to be queued. This will attempt to ensure the job is at least queued. 
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog
* Adds retry support when publishing locale job to nsq
<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
Needs a test for the buildPerLocale function so this is not quite ready.
<!--
Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
