### PR TITLE
[fix] Log spec more consistently to avoid spreading strings into log objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- Fix `packer.js` log entry so that the `spec.name` field doesn't end up spread in the log entry
+
 ### 6.0.1
 
 - [#61] Fix winson formatting broken with `winston@3` upgrade

--- a/lib/construct/packer.js
+++ b/lib/construct/packer.js
@@ -153,7 +153,7 @@ class Packer {
     const { tarball, installPath } = paths;
     const pkgDir = path.join(installPath, 'package');
 
-    this.log.info('Begin npm install & tarball repack', spec.name, spec);
+    this.log.info('Begin npm install & tarball repack', spec);
 
     await this.unpack({ content, installPath, statusWriter });
     await this.install({ spec, installPath, statusWriter });


### PR DESCRIPTION
## Summary

When using a json winston formatter, sending just a string to any log call ends up spreading that string into the object.  in this case if the `spec.name` being logged here was `wat` you end up with log output like

```js
{
  // other data
  "0": "w",
  "1": "a",
  "2": "t",
  "spec": {
    "name": "wat",
    // other spec data
  },
  "message": "Begin npm install & tarball repack"
}
```

## Changelog

```md
- Fix `packer.js` log entry so that the `spec.name` field doesn't end up spread in the log entry
```

## Test Plan

None
